### PR TITLE
PhysBone Collider Converter: ownership-scoped UI, safe re-convert updates, and marker cleanup

### DIFF
--- a/VRCSDK3Stub/VRCPstub/ManagedTypes/VRCParentConstraintBase.cs
+++ b/VRCSDK3Stub/VRCPstub/ManagedTypes/VRCParentConstraintBase.cs
@@ -20,7 +20,12 @@ namespace VRC.Dynamics.ManagedTypes
 
     public sealed override bool AffectsAnyAxis()
     {
-      return AffectsPositionX || AffectsPositionY || AffectsPositionZ || AffectsRotationX || AffectsRotationY || AffectsRotationZ;
+      return AffectsPositionX
+        || AffectsPositionY
+        || AffectsPositionZ
+        || AffectsRotationX
+        || AffectsRotationY
+        || AffectsRotationZ;
     }
   }
 }

--- a/VRCStubConvertAndUI/VRCAVUIAndConverter/Editors/VRCExpressionsMenuEditor.cs
+++ b/VRCStubConvertAndUI/VRCAVUIAndConverter/Editors/VRCExpressionsMenuEditor.cs
@@ -422,9 +422,7 @@ namespace VRC.SDK3.Avatars.Editors
           var machineName = GetMachineName(control);
           if (!string.IsNullOrEmpty(machineName) && !parameterInfo.ContainsKey(machineName))
           {
-            missingParameters.Add(
-              $"• {controlPath} ({control.type}) - Parameter: {control.parameter?.name}"
-            );
+            missingParameters.Add($"• {controlPath} ({control.type}) - Parameter: {control.parameter?.name}");
           }
         }
       }
@@ -745,7 +743,11 @@ namespace VRC.SDK3.Avatars.Editors
           if (control.type == VRCExpressionsMenu.Control.ControlType.SubMenu)
           {
             menuItem = ConvertSubMenuControl(
-              control, parameterStores, cvrMenuStoreType, visited, ref subMenusConverted
+              control,
+              parameterStores,
+              cvrMenuStoreType,
+              visited,
+              ref subMenusConverted
             );
           }
           else
@@ -772,7 +774,9 @@ namespace VRC.SDK3.Avatars.Editors
         // Log how many items were collected before setting the field
         var countProp = menuItemsListType.GetProperty("Count");
         int itemCount = countProp != null ? (int)countProp.GetValue(menuItemsList) : -1;
-        UnityEngine.Debug.Log($"[CVRFury Converter] ConvertMenuControls: setting {itemCount} menu item(s) on '{cvrMenuStore.name}'");
+        UnityEngine.Debug.Log(
+          $"[CVRFury Converter] ConvertMenuControls: setting {itemCount} menu item(s) on '{cvrMenuStore.name}'"
+        );
 
         // Set the menuItems field
         menuItemsField.SetValue(cvrMenuStore, menuItemsList);
@@ -797,9 +801,7 @@ namespace VRC.SDK3.Avatars.Editors
     {
       if (control.subMenu == null)
       {
-        UnityEngine.Debug.LogWarning(
-          $"SubMenu control '{control.name}' has no linked sub-menu asset — skipping"
-        );
+        UnityEngine.Debug.LogWarning($"SubMenu control '{control.name}' has no linked sub-menu asset — skipping");
         return null;
       }
 
@@ -814,9 +816,7 @@ namespace VRC.SDK3.Avatars.Editors
       var subAssetPath = AssetDatabase.GetAssetPath(control.subMenu);
       if (string.IsNullOrEmpty(subAssetPath))
       {
-        UnityEngine.Debug.LogWarning(
-          $"Sub-menu asset for '{control.name}' is not saved to disk — skipping"
-        );
+        UnityEngine.Debug.LogWarning($"Sub-menu asset for '{control.name}' is not saved to disk — skipping");
         return null;
       }
 
@@ -849,9 +849,7 @@ namespace VRC.SDK3.Avatars.Editors
 
       if (subMenuParamType == null)
       {
-        UnityEngine.Debug.LogError(
-          "subMenuParameter type not found — make sure CVRFury runtime is up to date"
-        );
+        UnityEngine.Debug.LogError("subMenuParameter type not found — make sure CVRFury runtime is up to date");
         return null;
       }
 
@@ -859,7 +857,9 @@ namespace VRC.SDK3.Avatars.Editors
       SetField(subMenuParam, "name", control.name.Trim());
       SetField(subMenuParam, "subMenuStore", childStore);
 
-      UnityEngine.Debug.Log($"[CVRFury Converter] Created subMenuParameter '{control.name.Trim()}' → '{childStore?.name}'");
+      UnityEngine.Debug.Log(
+        $"[CVRFury Converter] Created subMenuParameter '{control.name.Trim()}' → '{childStore?.name}'"
+      );
 
       return subMenuParam;
     }
@@ -974,7 +974,9 @@ namespace VRC.SDK3.Avatars.Editors
         case VRCExpressionsMenu.Control.ControlType.SubMenu:
           // SubMenu controls are handled before ConvertControl is called (in ConvertMenuControls).
           // If we somehow reach here, log and skip.
-          UnityEngine.Debug.LogWarning($"SubMenu control '{control.name}' reached ConvertControl unexpectedly — skipping");
+          UnityEngine.Debug.LogWarning(
+            $"SubMenu control '{control.name}' reached ConvertControl unexpectedly — skipping"
+          );
           return null;
 
         case VRCExpressionsMenu.Control.ControlType.FourAxisPuppet:

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/UIVersion.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/UIVersion.cs
@@ -4,7 +4,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors.Common
 {
   public static class UIVersion
   {
-    private static readonly Version _version = new Version(2, 1, 2);
+    private static readonly Version _version = new Version(2, 2, 0);
 
     public static string CurrentVersion => _version.ToString();
     public static Version AsVersion => _version;

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/UIVersion.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/UIVersion.cs
@@ -4,7 +4,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors.Common
 {
   public static class UIVersion
   {
-    private static readonly Version _version = new Version(2, 1, 0);
+    private static readonly Version _version = new Version(2, 1, 1);
 
     public static string CurrentVersion => _version.ToString();
     public static Version AsVersion => _version;

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/UIVersion.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/UIVersion.cs
@@ -4,7 +4,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors.Common
 {
   public static class UIVersion
   {
-    private static readonly Version _version = new Version(2, 2, 0);
+    private static readonly Version _version = new Version(2, 2, 1);
 
     public static string CurrentVersion => _version.ToString();
     public static Version AsVersion => _version;

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/UIVersion.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/UIVersion.cs
@@ -4,7 +4,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors.Common
 {
   public static class UIVersion
   {
-    private static readonly Version _version = new Version(2, 1, 1);
+    private static readonly Version _version = new Version(2, 1, 2);
 
     public static string CurrentVersion => _version.ToString();
     public static Version AsVersion => _version;

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/UIVersion.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/UIVersion.cs
@@ -4,7 +4,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors.Common
 {
   public static class UIVersion
   {
-    private static readonly Version _version = new Version(2, 0, 0);
+    private static readonly Version _version = new Version(2, 1, 0);
 
     public static string CurrentVersion => _version.ToString();
     public static Version AsVersion => _version;

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Editors/VRCPhysBoneColliderEditor.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Editors/VRCPhysBoneColliderEditor.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
 using UnityEngine;
 using UnityEngine.UIElements;
 using UnityEditor;
+using VRC.Dynamics;
 using VRC.SDK3.Dynamics.PhysBone.Components;
 using VRC.SDK3.Dynamics.PhysBone.Editors.Common;
 using uk.novavoidhowl.dev.cvrfury.VRCstub.Common; // Shared UI styles
@@ -8,7 +12,15 @@ using uk.novavoidhowl.dev.cvrfury.VRCstub.Common; // Shared UI styles
 namespace VRC.SDK3.Dynamics.PhysBone.Editors
 {
   /// <summary>
-  /// Custom editor for VRCPhysBoneCollider separated from the stub assembly.
+  /// Custom editor for VRCPhysBoneCollider: shows shape info and converts to
+  /// DynamicBone, MagicaCloth 1 and MagicaCloth 2 colliders.
+  ///
+  /// Each converted collider is placed on a new child GameObject created under
+  /// the collider's effective root transform (src.rootTransform if set, otherwise
+  /// src.transform). This mirrors how VRC resolves the collider's origin at runtime.
+  ///
+  /// Package detection is done at runtime via type-lookup — no compile-time
+  /// #if guards are needed because this file compiles to a precompiled DLL.
   /// </summary>
   [CustomEditor(typeof(VRCPhysBoneCollider))]
   public class VRCPhysBoneColliderEditor : Editor
@@ -20,12 +32,205 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
     private const string STUB_VERSION = "stub-version";
     private const string UI_VERSION = "ui-version";
 
+    // -------------------------------------------------------------------------
+    // Runtime package detection
+    // -------------------------------------------------------------------------
+
+    private static Type FindType(string fullTypeName)
+    {
+      foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+      {
+        var t = asm.GetType(fullTypeName);
+        if (t != null) return t;
+      }
+      return null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Axis helper — returns 0=X, 1=Y, 2=Z for the dominant axis of a quaternion
+    // -------------------------------------------------------------------------
+
+    private static int GetDominantAxis(Quaternion rotation)
+    {
+      Vector3 fwd = rotation * Vector3.forward;
+      float ax = Mathf.Abs(fwd.x);
+      float ay = Mathf.Abs(fwd.y);
+      float az = Mathf.Abs(fwd.z);
+      if (ax >= ay && ax >= az) return 0; // X
+      if (ay >= ax && ay >= az) return 1; // Y
+      return 2;                           // Z
+    }
+
+    // -------------------------------------------------------------------------
+    // Reflection helpers — walk the inheritance chain so base-class
+    // properties/fields are found when called on a derived type instance.
+    // -------------------------------------------------------------------------
+
+    private static void SetProp(object obj, string name, object value)
+    {
+      var type = obj.GetType();
+      while (type != null)
+      {
+        var prop = type.GetProperty(
+          name,
+          BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly
+        );
+        if (prop != null && prop.CanWrite)
+        {
+          prop.SetValue(obj, value);
+          return;
+        }
+        type = type.BaseType;
+      }
+      Debug.LogWarning($"[CVRFury] Property '{name}' not found on {obj.GetType().FullName}");
+    }
+
+    private static void SetField(object obj, string name, object value)
+    {
+      var type = obj.GetType();
+      while (type != null)
+      {
+        var field = type.GetField(
+          name,
+          BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly
+        );
+        if (field != null)
+        {
+          field.SetValue(obj, value);
+          return;
+        }
+        type = type.BaseType;
+      }
+      Debug.LogWarning($"[CVRFury] Field '{name}' not found on {obj.GetType().FullName}");
+    }
+
+    private static Type GetNestedTypeDeep(Type type, string nestedName)
+    {
+      while (type != null)
+      {
+        var nested = type.GetNestedType(nestedName, BindingFlags.Public);
+        if (nested != null) return nested;
+        type = type.BaseType;
+      }
+      return null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Create a named child GameObject under a parent, registered with Undo.
+    // The new GO is positioned at local identity so that the component's own
+    // center/offset field carries the position data from the VRC collider.
+    // -------------------------------------------------------------------------
+
+    private static GameObject CreateChildGameObject(string name, Transform parent)
+    {
+      var go = new GameObject(name);
+      Undo.RegisterCreatedObjectUndo(go, "Create converted collider");
+      go.transform.SetParent(parent, false);
+      go.transform.localPosition = Vector3.zero;
+      go.transform.localRotation = Quaternion.identity;
+      go.transform.localScale    = Vector3.one;
+      return go;
+    }
+
+    // -------------------------------------------------------------------------
+    // Existing-conversions UI section
+    // Clears then repopulates a persistent container with clickable navigation
+    // buttons for each already-converted collider found under effectiveRoot.
+    // Called once at Inspector-build time and again after each conversion so the
+    // list updates immediately without requiring a re-selection.
+    // -------------------------------------------------------------------------
+
+    private static void PopulateExistingConversions(
+      VisualElement container,
+      Transform effectiveRoot,
+      Type dbType,
+      Type[] mc1Types,
+      Type[] mc2Types)
+    {
+      container.Clear();
+
+      var found = new List<(string label, Component comp)>();
+
+      // DynamicBone
+      if (dbType != null)
+        foreach (Component c in effectiveRoot.GetComponentsInChildren(dbType, true))
+          found.Add(($"DynamicBoneCollider on \"{c.gameObject.name}\"", c));
+
+      // MagicaCloth 1
+      foreach (var t in mc1Types)
+      {
+        if (t == null) continue;
+        foreach (Component c in effectiveRoot.GetComponentsInChildren(t, true))
+          found.Add(($"{t.Name} (MC1) on \"{c.gameObject.name}\"", c));
+      }
+
+      // MagicaCloth 2
+      foreach (var t in mc2Types)
+      {
+        if (t == null) continue;
+        foreach (Component c in effectiveRoot.GetComponentsInChildren(t, true))
+          found.Add(($"{t.Name} (MC2) on \"{c.gameObject.name}\"", c));
+      }
+
+      // Leave container empty (invisible) when nothing found
+      if (found.Count == 0) return;
+
+      var box = new Box();
+      box.AddToClassList(CSS_INFO_BOX);
+
+      var heading = new Label("Existing converted colliders:");
+      heading.style.unityFontStyleAndWeight = FontStyle.Bold;
+      box.Add(heading);
+
+      foreach (var (label, comp) in found)
+      {
+        var capturedComp = comp;
+        var btn = new Button(() =>
+        {
+          Selection.activeGameObject = capturedComp.gameObject;
+          EditorGUIUtility.PingObject(capturedComp.gameObject);
+        });
+        btn.text = "\u2192 " + label;
+        btn.style.unityTextAlign = TextAnchor.MiddleLeft;
+        box.Add(btn);
+      }
+
+      container.Add(box);
+    }
+
+    // -------------------------------------------------------------------------
+    // Inspector GUI
+    // -------------------------------------------------------------------------
+
     public override VisualElement CreateInspectorGUI()
     {
+      var src = (VRCPhysBoneCollider)target;
+
+      // Detect physics packages at Inspector-open time via runtime type lookup.
+      // No #if guards — this file is a precompiled DLL and project defines are
+      // not available at its build time.
+      Type dbType         = FindType("DynamicBoneCollider");
+      Type mc1SphereType  = FindType("MagicaCloth.MagicaSphereCollider");
+      Type mc1CapsuleType = FindType("MagicaCloth.MagicaCapsuleCollider");
+      Type mc1PlaneType   = FindType("MagicaCloth.MagicaPlaneCollider");
+      Type mc2SphereType  = FindType("MagicaCloth2.MagicaSphereCollider");
+      Type mc2CapsuleType = FindType("MagicaCloth2.MagicaCapsuleCollider");
+      Type mc2PlaneType   = FindType("MagicaCloth2.MagicaPlaneCollider");
+
+      bool mc1Available = mc1SphereType != null && mc1CapsuleType != null && mc1PlaneType != null;
+      bool mc2Available = mc2SphereType != null && mc2CapsuleType != null && mc2PlaneType != null;
+      bool isPlane      = src.shapeType == VRCPhysBoneColliderBase.ShapeType.Plane;
+
+      // The effective root is where new collider GameObjects will be parented.
+      // VRC resolves the collider's world origin from rootTransform when set,
+      // so we match that behaviour for the converted colliders.
+      Transform effectiveRoot = src.rootTransform != null ? src.rootTransform : src.transform;
+
       var root = new VisualElement();
       root.AddToClassList(CSS_CVR_FURY_BUTTONS_CONTAINER);
 
-      var stubVersionLabel = new Label($"Stub Version: {((VRCPhysBoneCollider)target).StubVersion}");
+      // Version labels
+      var stubVersionLabel = new Label($"Stub Version: {src.StubVersion}");
       stubVersionLabel.AddToClassList(STUB_VERSION);
       root.Add(stubVersionLabel);
 
@@ -33,36 +238,433 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       uiVersionLabel.AddToClassList(UI_VERSION);
       root.Add(uiVersionLabel);
 
+      // Info box — shape description + root transform info + any up-front warnings
       var infoBox = new Box();
       infoBox.AddToClassList(CSS_INFO_BOX);
-      var infoLabel = new Label(
-        "This component needs to be converted for use in CVR. Automatic conversion is not available yet; you can remove the VRC component and set up the equivalent in CVR manually."
-      );
-      infoLabel.style.whiteSpace = WhiteSpace.Normal;
-      infoBox.Add(infoLabel);
 
-      var removeButton = new Button(() =>
+      string shapeDesc;
+      switch (src.shapeType)
       {
-        DestroyImmediate(target);
-      })
+        case VRCPhysBoneColliderBase.ShapeType.Sphere:
+          shapeDesc = "Sphere (radius only)";
+          break;
+        case VRCPhysBoneColliderBase.ShapeType.Capsule:
+          shapeDesc = "Capsule (radius + height)";
+          break;
+        case VRCPhysBoneColliderBase.ShapeType.Plane:
+          shapeDesc = "Plane (infinite flat plane)";
+          break;
+        default:
+          shapeDesc = src.shapeType.ToString();
+          break;
+      }
+
+      var shapeLabel = new Label($"Shape: {shapeDesc}");
+      shapeLabel.style.whiteSpace = WhiteSpace.Normal;
+      infoBox.Add(shapeLabel);
+
+      // Root transform info — always shown so the user knows where converted GOs land
+      string rootDesc = src.rootTransform != null
+        ? $"Root transform: {src.rootTransform.name} \u2014 converted colliders will be created as children of this transform."
+        : "No rootTransform set \u2014 converted colliders will be created as children of this GameObject.";
+      var rootInfoLabel = new Label(rootDesc);
+      rootInfoLabel.style.whiteSpace = WhiteSpace.Normal;
+      infoBox.Add(rootInfoLabel);
+
+      if (src.insideBounds)
+      {
+        var insideLabel = new Label(
+          "\u26a0 insideBounds is set \u2014 Inside mode is not supported by MagicaCloth; Outside will be used for MC1/MC2."
+        );
+        insideLabel.style.whiteSpace = WhiteSpace.Normal;
+        insideLabel.style.color = new StyleColor(new Color(1f, 0.75f, 0f));
+        infoBox.Add(insideLabel);
+      }
+
+      root.Add(infoBox);
+
+      // Existing conversions — persistent container; populated now and refreshed
+      // immediately after each conversion without needing a re-select.
+      var existingContainer = new VisualElement();
+      root.Add(existingContainer);
+      PopulateExistingConversions(
+        existingContainer,
+        effectiveRoot,
+        dbType,
+        new[] { mc1SphereType, mc1CapsuleType, mc1PlaneType },
+        new[] { mc2SphereType, mc2CapsuleType, mc2PlaneType }
+      );
+
+      // Spacer
+      var spacer1 = new VisualElement();
+      spacer1.AddToClassList(CSS_SPACER);
+      root.Add(spacer1);
+
+      // "Convert to:" heading
+      var convertLabel = new Label("Convert to:");
+      convertLabel.style.unityFontStyleAndWeight = FontStyle.Bold;
+      root.Add(convertLabel);
+
+      // -- Dynamic Bone toggle --
+      // Greyed out if: package not found OR shape is Plane (DB has no Plane collider)
+      bool dbCanConvert = dbType != null && !isPlane;
+      var dbToggle = new Toggle("Dynamic Bone Collider") { value = dbCanConvert };
+      if (!dbCanConvert)
+      {
+        dbToggle.SetEnabled(false);
+        dbToggle.tooltip = dbType == null
+          ? "DynamicBone package not detected. Run NVH \u2192 CVRFury \u2192 Integrations \u2192 Check Dynamic Bone Support first."
+          : "DynamicBone does not support Plane colliders.";
+      }
+      root.Add(dbToggle);
+
+      // -- MagicaCloth 1 toggle --
+      var mc1Toggle = new Toggle("MagicaCloth 1 Collider") { value = mc1Available };
+      if (!mc1Available)
+      {
+        mc1Toggle.SetEnabled(false);
+        mc1Toggle.tooltip = "MagicaCloth (v1) package not detected in this project.";
+      }
+      root.Add(mc1Toggle);
+
+      // -- MagicaCloth 2 toggle --
+      var mc2Toggle = new Toggle("MagicaCloth 2 Collider") { value = mc2Available };
+      if (!mc2Available)
+      {
+        mc2Toggle.SetEnabled(false);
+        mc2Toggle.tooltip =
+          "MagicaCloth 2 package not detected. Ensure it is imported and the MAGICACLOTH2 scripting define is present.";
+      }
+      root.Add(mc2Toggle);
+
+      // -- Convert button --
+      var convertButton = new Button { text = "Convert" };
+      convertButton.AddToClassList(CSS_CVR_FURY_BUTTON);
+      convertButton.style.marginTop = new StyleLength(6);
+
+      // Keep the Convert button enabled only while at least one enabled toggle is checked
+      Action updateConvertButton = () =>
+      {
+        bool any = (dbToggle.enabledSelf  && dbToggle.value)
+                || (mc1Toggle.enabledSelf && mc1Toggle.value)
+                || (mc2Toggle.enabledSelf && mc2Toggle.value);
+        convertButton.SetEnabled(any);
+      };
+
+      dbToggle.RegisterValueChangedCallback(_ => updateConvertButton());
+      mc1Toggle.RegisterValueChangedCallback(_ => updateConvertButton());
+      mc2Toggle.RegisterValueChangedCallback(_ => updateConvertButton());
+      updateConvertButton(); // set initial state
+
+      // Capture for click handler closure
+      VisualElement capturedExistingContainer = existingContainer;
+      Transform capturedEffectiveRoot  = effectiveRoot;
+      Type capturedDbType              = dbType;
+      Type capturedMc1SphereType       = mc1SphereType;
+      Type capturedMc1CapsuleType      = mc1CapsuleType;
+      Type capturedMc1PlaneType        = mc1PlaneType;
+      Type capturedMc2SphereType       = mc2SphereType;
+      Type capturedMc2CapsuleType      = mc2CapsuleType;
+      Type capturedMc2PlaneType        = mc2PlaneType;
+
+      convertButton.clicked += () =>
+      {
+        var converted = new List<string>();
+        var warnings  = new List<string>();
+
+        bool doDb  = dbToggle.enabledSelf  && dbToggle.value;
+        bool doMc1 = mc1Toggle.enabledSelf && mc1Toggle.value;
+        bool doMc2 = mc2Toggle.enabledSelf && mc2Toggle.value;
+
+        // Cross-cutting warnings
+        if (src.insideBounds && (doMc1 || doMc2))
+          warnings.Add("Inside-bounds is not supported by MagicaCloth \u2014 Outside mode applied.");
+
+        if (isPlane && (doMc1 || doMc2))
+          warnings.Add(
+            "Plane: VRC rotation has been applied to the new child GO's local rotation. Verify the orientation in the Scene view."
+          );
+
+        // Group all child-GO creation + component additions into one undoable step
+        Undo.IncrementCurrentGroup();
+        Undo.SetCurrentGroupName("Convert PhysBone Collider");
+
+        if (doDb)
+        {
+          ConvertToDynamicBone(src, capturedDbType, capturedEffectiveRoot);
+          converted.Add("DynamicBoneCollider");
+        }
+
+        if (doMc1)
+        {
+          string mc1Warning;
+          string mc1Name = ConvertToMagicaCloth1(
+            src,
+            capturedMc1SphereType, capturedMc1CapsuleType, capturedMc1PlaneType,
+            capturedEffectiveRoot,
+            out mc1Warning
+          );
+          converted.Add(mc1Name);
+          if (mc1Warning != null) warnings.Add(mc1Warning);
+        }
+
+        if (doMc2)
+        {
+          string mc2Name = ConvertToMagicaCloth2(
+            src,
+            capturedMc2SphereType, capturedMc2CapsuleType, capturedMc2PlaneType,
+            capturedEffectiveRoot
+          );
+          converted.Add(mc2Name);
+        }
+
+        // Summary dialog
+        string msg = "Created child GameObjects under \"" + capturedEffectiveRoot.name + "\":\n"
+                   + string.Join(", ", converted.ToArray());
+        if (warnings.Count > 0)
+        {
+          msg += "\n\nWarnings:";
+          foreach (var w in warnings)
+            msg += "\n\u2022 " + w;
+        }
+        EditorUtility.DisplayDialog("PhysBone Collider Converted", msg, "OK");
+
+        // Refresh the existing-conversions panel immediately so the new links
+        // appear without the user needing to deselect and reselect the object.
+        PopulateExistingConversions(
+          capturedExistingContainer,
+          capturedEffectiveRoot,
+          capturedDbType,
+          new[] { capturedMc1SphereType, capturedMc1CapsuleType, capturedMc1PlaneType },
+          new[] { capturedMc2SphereType, capturedMc2CapsuleType, capturedMc2PlaneType }
+        );
+      };
+
+      root.Add(convertButton);
+
+      // Spacer before Remove
+      var spacer2 = new VisualElement();
+      spacer2.AddToClassList(CSS_SPACER);
+      root.Add(spacer2);
+
+      // Remove button
+      var removeButton = new Button(() => DestroyImmediate(target))
       {
         text = "Remove VRC PhysBone Collider Component"
       };
       removeButton.AddToClassList(CSS_CVR_FURY_BUTTON);
-
-      var spacer = new VisualElement();
-      spacer.AddToClassList(CSS_SPACER);
-
-      root.Add(infoBox);
       root.Add(removeButton);
-      root.Add(spacer);
+
+      // Trailing spacer
+      var spacer3 = new VisualElement();
+      spacer3.AddToClassList(CSS_SPACER);
+      root.Add(spacer3);
 
       SharedUIStyles.ApplySharedStyles(root);
-      root.AddToClassList(CSS_CVR_FURY_BUTTONS_CONTAINER);
-      var removeButtons = root.Query<Button>().Where(b => b.text.Contains("Remove")).ToList();
-      foreach (var button in removeButtons)
-        button.AddToClassList(CSS_CVR_FURY_BUTTON);
       return root;
+    }
+
+    // -------------------------------------------------------------------------
+    // Conversion: DynamicBone
+    // Creates a new child GO under effectiveRoot, then uses SerializedObject to
+    // set the (public) fields robustly through Unity's serialization layer.
+    // -------------------------------------------------------------------------
+
+    private static void ConvertToDynamicBone(
+      VRCPhysBoneCollider src, Type dbType, Transform effectiveRoot)
+    {
+      if (src.shapeType == VRCPhysBoneColliderBase.ShapeType.Plane)
+      {
+        Debug.LogError("[CVRFury] ConvertToDynamicBone called with Plane shape \u2014 aborting.");
+        return;
+      }
+
+      var newGO = CreateChildGameObject(src.gameObject.name + "_DBCollider", effectiveRoot);
+
+      // VRC capsule extends along its Y-axis; apply the VRC rotation to the child GO
+      // so that direction Y on the DynamicBoneCollider aligns with the intended capsule axis.
+      // (For spheres the rotation has no meaningful effect but applying it is harmless.)
+      if (src.shapeType == VRCPhysBoneColliderBase.ShapeType.Capsule)
+        newGO.transform.localRotation = src.rotation;
+
+      var dbc   = ObjectFactory.AddComponent(newGO, dbType);
+      var so    = new SerializedObject(dbc);
+
+      var radProp = so.FindProperty("m_Radius");
+      var hProp   = so.FindProperty("m_Height");
+      var cProp   = so.FindProperty("m_Center");
+      var dirProp = so.FindProperty("m_Direction");
+      var bndProp = so.FindProperty("m_Bound");
+
+      if (radProp != null) radProp.floatValue     = src.radius;
+      if (hProp   != null) hProp.floatValue       =
+        src.shapeType == VRCPhysBoneColliderBase.ShapeType.Capsule ? src.height : 0f;
+      if (cProp   != null) cProp.vector3Value     = src.position;
+      // Always use Y-axis (1) — VRC's natural capsule axis is Y; orientation is carried by localRotation.
+      if (dirProp != null) dirProp.enumValueIndex = 1;
+      if (bndProp != null) bndProp.enumValueIndex = src.insideBounds ? 1 : 0; // 0=Outside 1=Inside
+
+      so.ApplyModifiedProperties();
+      EditorUtility.SetDirty(newGO);
+    }
+
+    // -------------------------------------------------------------------------
+    // Conversion: MagicaCloth 1
+    // Creates a new child GO under effectiveRoot per shape type.
+    // MC1 fields are [SerializeField] private; access via their public properties.
+    // Returns the display name of the added component, and an optional warning.
+    // -------------------------------------------------------------------------
+
+    private static string ConvertToMagicaCloth1(
+      VRCPhysBoneCollider src,
+      Type mc1SphereType, Type mc1CapsuleType, Type mc1PlaneType,
+      Transform effectiveRoot,
+      out string warning)
+    {
+      warning = null;
+      string addedName;
+
+      switch (src.shapeType)
+      {
+        case VRCPhysBoneColliderBase.ShapeType.Sphere:
+        {
+          var newGO = CreateChildGameObject(src.gameObject.name + "_MC1SphereCollider", effectiveRoot);
+          var c = ObjectFactory.AddComponent(newGO, mc1SphereType);
+          SetProp(c, "Radius", src.radius);
+          SetProp(c, "Center", src.position);
+          EditorUtility.SetDirty(newGO);
+          addedName = "MagicaSphereCollider (MC1)";
+          break;
+        }
+        case VRCPhysBoneColliderBase.ShapeType.Capsule:
+        {
+          var newGO = CreateChildGameObject(src.gameObject.name + "_MC1CapsuleCollider", effectiveRoot);
+          // VRC capsule extends along its Y-axis; apply VRC rotation to the child GO
+          // so the GO's local Y aligns with the intended capsule axis.
+          newGO.transform.localRotation = src.rotation;
+          var c = ObjectFactory.AddComponent(newGO, mc1CapsuleType);
+
+          // AxisMode: always Y (1) — VRC's natural capsule axis is Y; orientation carried by GO's rotation.
+          var axisEnumType = GetNestedTypeDeep(mc1CapsuleType, "Axis");
+          if (axisEnumType != null)
+            SetProp(c, "AxisMode", Enum.ToObject(axisEnumType, 1));
+
+          // MC1 Length is a HALF-length (distance from center to one end sphere).
+          // Total visual span = 2*Length + 2*radius. MC2/VRC height = total tip-to-tip,
+          // so: Length = src.height/2 - src.radius (clamped to MC1's [Range(0,1)] max).
+          float mc1HalfLen = Mathf.Max(src.height / 2f - src.radius, 0f);
+          float clampedLength = Mathf.Clamp(mc1HalfLen, 0f, 1f);
+          if (mc1HalfLen > 1f)
+            warning = $"MC1 capsule half-length ({mc1HalfLen:F3}\u202fm) exceeds MC1 max (1.0\u202fm) and was clamped. Original VRC height: {src.height:F3}\u202fm.";
+
+          SetProp(c, "Length",      clampedLength);
+          SetProp(c, "StartRadius", src.radius);
+          SetProp(c, "EndRadius",   src.radius);
+          SetProp(c, "Center",      src.position);
+          EditorUtility.SetDirty(newGO);
+          addedName = "MagicaCapsuleCollider (MC1)";
+          break;
+        }
+        case VRCPhysBoneColliderBase.ShapeType.Plane:
+        {
+          var newGO = CreateChildGameObject(src.gameObject.name + "_MC1PlaneCollider", effectiveRoot);
+          // MC1 uses the GO's Y+ axis as the plane normal — apply the VRC rotation so
+          // the Y+ of this child GO matches the intended plane normal direction.
+          newGO.transform.localRotation = src.rotation;
+          var c = ObjectFactory.AddComponent(newGO, mc1PlaneType);
+          SetProp(c, "Center", src.position);
+          EditorUtility.SetDirty(newGO);
+          addedName = "MagicaPlaneCollider (MC1)";
+          break;
+        }
+        default:
+          return "MagicaCloth1 (unknown shape)";
+      }
+
+      return addedName;
+    }
+
+    // -------------------------------------------------------------------------
+    // Conversion: MagicaCloth 2
+    // Creates a new child GO under effectiveRoot per shape type.
+    // MC2 exposes public fields (center, direction, radiusSeparation,
+    // alignedOnCenter) and public SetSize() methods on each collider type.
+    // Returns the display name of the added component.
+    // -------------------------------------------------------------------------
+
+    private static string ConvertToMagicaCloth2(
+      VRCPhysBoneCollider src,
+      Type mc2SphereType, Type mc2CapsuleType, Type mc2PlaneType,
+      Transform effectiveRoot)
+    {
+      string addedName;
+
+      switch (src.shapeType)
+      {
+        case VRCPhysBoneColliderBase.ShapeType.Sphere:
+        {
+          var newGO = CreateChildGameObject(src.gameObject.name + "_MC2SphereCollider", effectiveRoot);
+          var c = ObjectFactory.AddComponent(newGO, mc2SphereType);
+          SetField(c, "center", src.position);
+
+          // MagicaSphereCollider.SetSize(float radius) sets size = new Vector3(r,0,0)
+          var setSizeFloat = mc2SphereType.GetMethod("SetSize", new[] { typeof(float) });
+          if (setSizeFloat != null)
+            setSizeFloat.Invoke(c, new object[] { src.radius });
+          else
+            SetField(c, "size", new Vector3(src.radius, 0f, 0f)); // fallback
+
+          EditorUtility.SetDirty(newGO);
+          addedName = "MagicaSphereCollider (MC2)";
+          break;
+        }
+        case VRCPhysBoneColliderBase.ShapeType.Capsule:
+        {
+          var newGO = CreateChildGameObject(src.gameObject.name + "_MC2CapsuleCollider", effectiveRoot);
+          // VRC capsule extends along its Y-axis; apply VRC rotation to the child GO
+          // so the GO's local Y aligns with the intended capsule axis.
+          newGO.transform.localRotation = src.rotation;
+          var c = ObjectFactory.AddComponent(newGO, mc2CapsuleType);
+          SetField(c, "center", src.position);
+
+          // Direction: always Y (1) — VRC's natural capsule axis is Y; orientation carried by GO's rotation.
+          var dirEnumType = GetNestedTypeDeep(mc2CapsuleType, "Direction");
+          if (dirEnumType != null)
+            SetField(c, "direction", Enum.ToObject(dirEnumType, 1)); // 1 = Y-Axis
+
+          SetField(c, "radiusSeparation", false); // uniform radius
+          SetField(c, "alignedOnCenter",  true);
+
+          // MagicaCapsuleCollider.SetSize(float startR, float endR, float length)
+          var setSizeThree = mc2CapsuleType.GetMethod(
+            "SetSize", new[] { typeof(float), typeof(float), typeof(float) }
+          );
+          if (setSizeThree != null)
+            setSizeThree.Invoke(c, new object[] { src.radius, src.radius, src.height });
+          else
+            SetField(c, "size", new Vector3(src.radius, src.radius, src.height)); // fallback
+
+          EditorUtility.SetDirty(newGO);
+          addedName = "MagicaCapsuleCollider (MC2)";
+          break;
+        }
+        case VRCPhysBoneColliderBase.ShapeType.Plane:
+        {
+          var newGO = CreateChildGameObject(src.gameObject.name + "_MC2PlaneCollider", effectiveRoot);
+          // MC2 uses the GO's Y+ axis as the plane normal — apply the VRC rotation so
+          // the Y+ of this child GO matches the intended plane normal direction.
+          newGO.transform.localRotation = src.rotation;
+          var c = ObjectFactory.AddComponent(newGO, mc2PlaneType);
+          SetField(c, "center", src.position);
+          EditorUtility.SetDirty(newGO);
+          addedName = "MagicaPlaneCollider (MC2)";
+          break;
+        }
+        default:
+          return "MagicaCloth2 (unknown shape)";
+      }
+
+      return addedName;
     }
   }
 }

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Editors/VRCPhysBoneColliderEditor.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Editors/VRCPhysBoneColliderEditor.cs
@@ -41,7 +41,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
       {
         var t = asm.GetType(fullTypeName);
-        if (t != null) return t;
+        if (t != null)
+          return t;
       }
       return null;
     }
@@ -56,9 +57,11 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       float ax = Mathf.Abs(fwd.x);
       float ay = Mathf.Abs(fwd.y);
       float az = Mathf.Abs(fwd.z);
-      if (ax >= ay && ax >= az) return 0; // X
-      if (ay >= ax && ay >= az) return 1; // Y
-      return 2;                           // Z
+      if (ax >= ay && ax >= az)
+        return 0; // X
+      if (ay >= ax && ay >= az)
+        return 1; // Y
+      return 2; // Z
     }
 
     // -------------------------------------------------------------------------
@@ -71,10 +74,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       var type = obj.GetType();
       while (type != null)
       {
-        var prop = type.GetProperty(
-          name,
-          BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly
-        );
+        var prop = type.GetProperty(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
         if (prop != null && prop.CanWrite)
         {
           prop.SetValue(obj, value);
@@ -90,10 +90,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       var type = obj.GetType();
       while (type != null)
       {
-        var field = type.GetField(
-          name,
-          BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly
-        );
+        var field = type.GetField(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
         if (field != null)
         {
           field.SetValue(obj, value);
@@ -109,7 +106,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       while (type != null)
       {
         var nested = type.GetNestedType(nestedName, BindingFlags.Public);
-        if (nested != null) return nested;
+        if (nested != null)
+          return nested;
         type = type.BaseType;
       }
       return null;
@@ -128,7 +126,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       go.transform.SetParent(parent, false);
       go.transform.localPosition = Vector3.zero;
       go.transform.localRotation = Quaternion.identity;
-      go.transform.localScale    = Vector3.one;
+      go.transform.localScale = Vector3.one;
       return go;
     }
 
@@ -138,8 +136,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
     // Used by the conversion methods to update in place instead of duplicating.
     // -------------------------------------------------------------------------
 
-    private static GameObject FindExistingConvertedGO(
-      Transform effectiveRoot, VRCPhysBoneCollider src, Type targetType)
+    private static GameObject FindExistingConvertedGO(Transform effectiveRoot, VRCPhysBoneCollider src, Type targetType)
     {
       foreach (Component c in effectiveRoot.GetComponentsInChildren(targetType, true))
       {
@@ -156,14 +153,21 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
     // -------------------------------------------------------------------------
 
     private static bool HasAnyExistingConversions(
-      Transform effectiveRoot, VRCPhysBoneCollider src,
-      Type dbType, Type[] mc1Types, Type[] mc2Types)
+      Transform effectiveRoot,
+      VRCPhysBoneCollider src,
+      Type dbType,
+      Type[] mc1Types,
+      Type[] mc2Types
+    )
     {
-      if (dbType != null && FindExistingConvertedGO(effectiveRoot, src, dbType) != null) return true;
+      if (dbType != null && FindExistingConvertedGO(effectiveRoot, src, dbType) != null)
+        return true;
       foreach (var t in mc1Types)
-        if (t != null && FindExistingConvertedGO(effectiveRoot, src, t) != null) return true;
+        if (t != null && FindExistingConvertedGO(effectiveRoot, src, t) != null)
+          return true;
       foreach (var t in mc2Types)
-        if (t != null && FindExistingConvertedGO(effectiveRoot, src, t) != null) return true;
+        if (t != null && FindExistingConvertedGO(effectiveRoot, src, t) != null)
+          return true;
       return false;
     }
 
@@ -181,7 +185,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       Transform effectiveRoot,
       Type dbType,
       Type[] mc1Types,
-      Type[] mc2Types)
+      Type[] mc2Types
+    )
     {
       container.Clear();
 
@@ -199,7 +204,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       // MagicaCloth 1 — only include GOs whose marker references this src collider
       foreach (var t in mc1Types)
       {
-        if (t == null) continue;
+        if (t == null)
+          continue;
         foreach (Component c in effectiveRoot.GetComponentsInChildren(t, true))
         {
           var marker = c.GetComponent<CVRFuryConvertedColliderMarker>();
@@ -211,7 +217,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       // MagicaCloth 2 — only include GOs whose marker references this src collider
       foreach (var t in mc2Types)
       {
-        if (t == null) continue;
+        if (t == null)
+          continue;
         foreach (Component c in effectiveRoot.GetComponentsInChildren(t, true))
         {
           var marker = c.GetComponent<CVRFuryConvertedColliderMarker>();
@@ -221,7 +228,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       }
 
       // Leave container empty (invisible) when nothing found
-      if (found.Count == 0) return;
+      if (found.Count == 0)
+        return;
 
       var box = new Box();
       box.AddToClassList(CSS_INFO_BOX);
@@ -257,17 +265,17 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       // Detect physics packages at Inspector-open time via runtime type lookup.
       // No #if guards — this file is a precompiled DLL and project defines are
       // not available at its build time.
-      Type dbType         = FindType("DynamicBoneCollider");
-      Type mc1SphereType  = FindType("MagicaCloth.MagicaSphereCollider");
+      Type dbType = FindType("DynamicBoneCollider");
+      Type mc1SphereType = FindType("MagicaCloth.MagicaSphereCollider");
       Type mc1CapsuleType = FindType("MagicaCloth.MagicaCapsuleCollider");
-      Type mc1PlaneType   = FindType("MagicaCloth.MagicaPlaneCollider");
-      Type mc2SphereType  = FindType("MagicaCloth2.MagicaSphereCollider");
+      Type mc1PlaneType = FindType("MagicaCloth.MagicaPlaneCollider");
+      Type mc2SphereType = FindType("MagicaCloth2.MagicaSphereCollider");
       Type mc2CapsuleType = FindType("MagicaCloth2.MagicaCapsuleCollider");
-      Type mc2PlaneType   = FindType("MagicaCloth2.MagicaPlaneCollider");
+      Type mc2PlaneType = FindType("MagicaCloth2.MagicaPlaneCollider");
 
       bool mc1Available = mc1SphereType != null && mc1CapsuleType != null && mc1PlaneType != null;
       bool mc2Available = mc2SphereType != null && mc2CapsuleType != null && mc2PlaneType != null;
-      bool isPlane      = src.shapeType == VRCPhysBoneColliderBase.ShapeType.Plane;
+      bool isPlane = src.shapeType == VRCPhysBoneColliderBase.ShapeType.Plane;
 
       // The effective root is where new collider GameObjects will be parented.
       // VRC resolves the collider's world origin from rootTransform when set,
@@ -312,9 +320,10 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       infoBox.Add(shapeLabel);
 
       // Root transform info — always shown so the user knows where converted GOs land
-      string rootDesc = src.rootTransform != null
-        ? $"Root transform: {src.rootTransform.name} \u2014 converted colliders will be created as children of this transform."
-        : "No rootTransform set \u2014 converted colliders will be created as children of this GameObject.";
+      string rootDesc =
+        src.rootTransform != null
+          ? $"Root transform: {src.rootTransform.name} \u2014 converted colliders will be created as children of this transform."
+          : "No rootTransform set \u2014 converted colliders will be created as children of this GameObject.";
       var rootInfoLabel = new Label(rootDesc);
       rootInfoLabel.style.whiteSpace = WhiteSpace.Normal;
       infoBox.Add(rootInfoLabel);
@@ -361,9 +370,10 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       if (!dbCanConvert)
       {
         dbToggle.SetEnabled(false);
-        dbToggle.tooltip = dbType == null
-          ? "DynamicBone package not detected. Run NVH \u2192 CVRFury \u2192 Integrations \u2192 Check Dynamic Bone Support first."
-          : "DynamicBone does not support Plane colliders.";
+        dbToggle.tooltip =
+          dbType == null
+            ? "DynamicBone package not detected. Run NVH \u2192 CVRFury \u2192 Integrations \u2192 Check Dynamic Bone Support first."
+            : "DynamicBone does not support Plane colliders.";
       }
       root.Add(dbToggle);
 
@@ -389,9 +399,12 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       // -- Convert button --
       // Label is "Re-Convert" if any conversions already exist for this source collider.
       bool hasExistingConversions = HasAnyExistingConversions(
-        effectiveRoot, src, dbType,
+        effectiveRoot,
+        src,
+        dbType,
         new[] { mc1SphereType, mc1CapsuleType, mc1PlaneType },
-        new[] { mc2SphereType, mc2CapsuleType, mc2PlaneType });
+        new[] { mc2SphereType, mc2CapsuleType, mc2PlaneType }
+      );
       var convertButton = new Button { text = hasExistingConversions ? "Re-Convert" : "Convert" };
       convertButton.AddToClassList(CSS_CVR_FURY_BUTTON);
       convertButton.style.marginTop = new StyleLength(6);
@@ -399,9 +412,10 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       // Keep the Convert button enabled only while at least one enabled toggle is checked
       Action updateConvertButton = () =>
       {
-        bool any = (dbToggle.enabledSelf  && dbToggle.value)
-                || (mc1Toggle.enabledSelf && mc1Toggle.value)
-                || (mc2Toggle.enabledSelf && mc2Toggle.value);
+        bool any =
+          (dbToggle.enabledSelf && dbToggle.value)
+          || (mc1Toggle.enabledSelf && mc1Toggle.value)
+          || (mc2Toggle.enabledSelf && mc2Toggle.value);
         convertButton.SetEnabled(any);
       };
 
@@ -412,21 +426,21 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
 
       // Capture for click handler closure
       VisualElement capturedExistingContainer = existingContainer;
-      Transform capturedEffectiveRoot  = effectiveRoot;
-      Type capturedDbType              = dbType;
-      Type capturedMc1SphereType       = mc1SphereType;
-      Type capturedMc1CapsuleType      = mc1CapsuleType;
-      Type capturedMc1PlaneType        = mc1PlaneType;
-      Type capturedMc2SphereType       = mc2SphereType;
-      Type capturedMc2CapsuleType      = mc2CapsuleType;
-      Type capturedMc2PlaneType        = mc2PlaneType;
+      Transform capturedEffectiveRoot = effectiveRoot;
+      Type capturedDbType = dbType;
+      Type capturedMc1SphereType = mc1SphereType;
+      Type capturedMc1CapsuleType = mc1CapsuleType;
+      Type capturedMc1PlaneType = mc1PlaneType;
+      Type capturedMc2SphereType = mc2SphereType;
+      Type capturedMc2CapsuleType = mc2CapsuleType;
+      Type capturedMc2PlaneType = mc2PlaneType;
 
       convertButton.clicked += () =>
       {
         var converted = new List<string>();
-        var warnings  = new List<string>();
+        var warnings = new List<string>();
 
-        bool doDb  = dbToggle.enabledSelf  && dbToggle.value;
+        bool doDb = dbToggle.enabledSelf && dbToggle.value;
         bool doMc1 = mc1Toggle.enabledSelf && mc1Toggle.value;
         bool doMc2 = mc2Toggle.enabledSelf && mc2Toggle.value;
 
@@ -454,27 +468,35 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
           string mc1Warning;
           string mc1Name = ConvertToMagicaCloth1(
             src,
-            capturedMc1SphereType, capturedMc1CapsuleType, capturedMc1PlaneType,
+            capturedMc1SphereType,
+            capturedMc1CapsuleType,
+            capturedMc1PlaneType,
             capturedEffectiveRoot,
             out mc1Warning
           );
           converted.Add(mc1Name);
-          if (mc1Warning != null) warnings.Add(mc1Warning);
+          if (mc1Warning != null)
+            warnings.Add(mc1Warning);
         }
 
         if (doMc2)
         {
           string mc2Name = ConvertToMagicaCloth2(
             src,
-            capturedMc2SphereType, capturedMc2CapsuleType, capturedMc2PlaneType,
+            capturedMc2SphereType,
+            capturedMc2CapsuleType,
+            capturedMc2PlaneType,
             capturedEffectiveRoot
           );
           converted.Add(mc2Name);
         }
 
         // Summary dialog
-        string msg = "Created child GameObjects under \"" + capturedEffectiveRoot.name + "\":\n"
-                   + string.Join(", ", converted.ToArray());
+        string msg =
+          "Created child GameObjects under \""
+          + capturedEffectiveRoot.name
+          + "\":\n"
+          + string.Join(", ", converted.ToArray());
         if (warnings.Count > 0)
         {
           msg += "\n\nWarnings:";
@@ -506,7 +528,17 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       root.Add(spacer2);
 
       // Remove button
-      var removeButton = new Button(() => DestroyImmediate(target))
+      // Also destroys any CVRFuryConvertedColliderMarker components that reference
+      // this source collider — once the source is gone the markers serve no purpose.
+      var removeButton = new Button(() =>
+      {
+        foreach (var marker in effectiveRoot.GetComponentsInChildren<CVRFuryConvertedColliderMarker>(true))
+        {
+          if (marker.sourceCollider == src)
+            DestroyImmediate(marker);
+        }
+        DestroyImmediate(target);
+      })
       {
         text = "Remove VRC PhysBone Collider Component"
       };
@@ -528,8 +560,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
     // set the (public) fields robustly through Unity's serialization layer.
     // -------------------------------------------------------------------------
 
-    private static void ConvertToDynamicBone(
-      VRCPhysBoneCollider src, Type dbType, Transform effectiveRoot)
+    private static void ConvertToDynamicBone(VRCPhysBoneCollider src, Type dbType, Transform effectiveRoot)
     {
       if (src.shapeType == VRCPhysBoneColliderBase.ShapeType.Plane)
       {
@@ -547,21 +578,25 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
         newGO.transform.localRotation = src.rotation;
 
       var dbc = newGO.GetComponent(dbType) ?? ObjectFactory.AddComponent(newGO, dbType);
-      var so  = new SerializedObject(dbc);
+      var so = new SerializedObject(dbc);
 
       var radProp = so.FindProperty("m_Radius");
-      var hProp   = so.FindProperty("m_Height");
-      var cProp   = so.FindProperty("m_Center");
+      var hProp = so.FindProperty("m_Height");
+      var cProp = so.FindProperty("m_Center");
       var dirProp = so.FindProperty("m_Direction");
       var bndProp = so.FindProperty("m_Bound");
 
-      if (radProp != null) radProp.floatValue     = src.radius;
-      if (hProp   != null) hProp.floatValue       =
-        src.shapeType == VRCPhysBoneColliderBase.ShapeType.Capsule ? src.height : 0f;
-      if (cProp   != null) cProp.vector3Value     = src.position;
+      if (radProp != null)
+        radProp.floatValue = src.radius;
+      if (hProp != null)
+        hProp.floatValue = src.shapeType == VRCPhysBoneColliderBase.ShapeType.Capsule ? src.height : 0f;
+      if (cProp != null)
+        cProp.vector3Value = src.position;
       // Always use Y-axis (1) — VRC's natural capsule axis is Y; orientation is carried by localRotation.
-      if (dirProp != null) dirProp.enumValueIndex = 1;
-      if (bndProp != null) bndProp.enumValueIndex = src.insideBounds ? 1 : 0; // 0=Outside 1=Inside
+      if (dirProp != null)
+        dirProp.enumValueIndex = 1;
+      if (bndProp != null)
+        bndProp.enumValueIndex = src.insideBounds ? 1 : 0; // 0=Outside 1=Inside
 
       so.ApplyModifiedProperties();
       if (existingDbGO == null)
@@ -581,9 +616,12 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
 
     private static string ConvertToMagicaCloth1(
       VRCPhysBoneCollider src,
-      Type mc1SphereType, Type mc1CapsuleType, Type mc1PlaneType,
+      Type mc1SphereType,
+      Type mc1CapsuleType,
+      Type mc1PlaneType,
       Transform effectiveRoot,
-      out string warning)
+      out string warning
+    )
     {
       warning = null;
       string addedName;
@@ -593,7 +631,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
         case VRCPhysBoneColliderBase.ShapeType.Sphere:
         {
           var existingMc1SphereGO = FindExistingConvertedGO(effectiveRoot, src, mc1SphereType);
-          var newGO = existingMc1SphereGO ?? CreateChildGameObject(src.gameObject.name + "_MC1SphereCollider", effectiveRoot);
+          var newGO =
+            existingMc1SphereGO ?? CreateChildGameObject(src.gameObject.name + "_MC1SphereCollider", effectiveRoot);
           var c = newGO.GetComponent(mc1SphereType) ?? ObjectFactory.AddComponent(newGO, mc1SphereType);
           SetProp(c, "Radius", src.radius);
           SetProp(c, "Center", src.position);
@@ -609,7 +648,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
         case VRCPhysBoneColliderBase.ShapeType.Capsule:
         {
           var existingMc1CapsGO = FindExistingConvertedGO(effectiveRoot, src, mc1CapsuleType);
-          var newGO = existingMc1CapsGO ?? CreateChildGameObject(src.gameObject.name + "_MC1CapsuleCollider", effectiveRoot);
+          var newGO =
+            existingMc1CapsGO ?? CreateChildGameObject(src.gameObject.name + "_MC1CapsuleCollider", effectiveRoot);
           // VRC capsule extends along its Y-axis; apply VRC rotation to the child GO
           // so the GO's local Y aligns with the intended capsule axis.
           newGO.transform.localRotation = src.rotation;
@@ -626,12 +666,13 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
           float mc1HalfLen = Mathf.Max(src.height / 2f - src.radius, 0f);
           float clampedLength = Mathf.Clamp(mc1HalfLen, 0f, 1f);
           if (mc1HalfLen > 1f)
-            warning = $"MC1 capsule half-length ({mc1HalfLen:F3}\u202fm) exceeds MC1 max (1.0\u202fm) and was clamped. Original VRC height: {src.height:F3}\u202fm.";
+            warning =
+              $"MC1 capsule half-length ({mc1HalfLen:F3}\u202fm) exceeds MC1 max (1.0\u202fm) and was clamped. Original VRC height: {src.height:F3}\u202fm.";
 
-          SetProp(c, "Length",      clampedLength);
+          SetProp(c, "Length", clampedLength);
           SetProp(c, "StartRadius", src.radius);
-          SetProp(c, "EndRadius",   src.radius);
-          SetProp(c, "Center",      src.position);
+          SetProp(c, "EndRadius", src.radius);
+          SetProp(c, "Center", src.position);
           if (existingMc1CapsGO == null)
           {
             var mc1CapsMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
@@ -644,7 +685,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
         case VRCPhysBoneColliderBase.ShapeType.Plane:
         {
           var existingMc1PlaneGO = FindExistingConvertedGO(effectiveRoot, src, mc1PlaneType);
-          var newGO = existingMc1PlaneGO ?? CreateChildGameObject(src.gameObject.name + "_MC1PlaneCollider", effectiveRoot);
+          var newGO =
+            existingMc1PlaneGO ?? CreateChildGameObject(src.gameObject.name + "_MC1PlaneCollider", effectiveRoot);
           // MC1 uses the GO's Y+ axis as the plane normal — apply the VRC rotation so
           // the Y+ of this child GO matches the intended plane normal direction.
           newGO.transform.localRotation = src.rotation;
@@ -676,8 +718,11 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
 
     private static string ConvertToMagicaCloth2(
       VRCPhysBoneCollider src,
-      Type mc2SphereType, Type mc2CapsuleType, Type mc2PlaneType,
-      Transform effectiveRoot)
+      Type mc2SphereType,
+      Type mc2CapsuleType,
+      Type mc2PlaneType,
+      Transform effectiveRoot
+    )
     {
       string addedName;
 
@@ -686,7 +731,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
         case VRCPhysBoneColliderBase.ShapeType.Sphere:
         {
           var existingMc2SphereGO = FindExistingConvertedGO(effectiveRoot, src, mc2SphereType);
-          var newGO = existingMc2SphereGO ?? CreateChildGameObject(src.gameObject.name + "_MC2SphereCollider", effectiveRoot);
+          var newGO =
+            existingMc2SphereGO ?? CreateChildGameObject(src.gameObject.name + "_MC2SphereCollider", effectiveRoot);
           var c = newGO.GetComponent(mc2SphereType) ?? ObjectFactory.AddComponent(newGO, mc2SphereType);
           SetField(c, "center", src.position);
 
@@ -709,7 +755,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
         case VRCPhysBoneColliderBase.ShapeType.Capsule:
         {
           var existingMc2CapsGO = FindExistingConvertedGO(effectiveRoot, src, mc2CapsuleType);
-          var newGO = existingMc2CapsGO ?? CreateChildGameObject(src.gameObject.name + "_MC2CapsuleCollider", effectiveRoot);
+          var newGO =
+            existingMc2CapsGO ?? CreateChildGameObject(src.gameObject.name + "_MC2CapsuleCollider", effectiveRoot);
           // VRC capsule extends along its Y-axis; apply VRC rotation to the child GO
           // so the GO's local Y aligns with the intended capsule axis.
           newGO.transform.localRotation = src.rotation;
@@ -722,12 +769,10 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
             SetField(c, "direction", Enum.ToObject(dirEnumType, 1)); // 1 = Y-Axis
 
           SetField(c, "radiusSeparation", false); // uniform radius
-          SetField(c, "alignedOnCenter",  true);
+          SetField(c, "alignedOnCenter", true);
 
           // MagicaCapsuleCollider.SetSize(float startR, float endR, float length)
-          var setSizeThree = mc2CapsuleType.GetMethod(
-            "SetSize", new[] { typeof(float), typeof(float), typeof(float) }
-          );
+          var setSizeThree = mc2CapsuleType.GetMethod("SetSize", new[] { typeof(float), typeof(float), typeof(float) });
           if (setSizeThree != null)
             setSizeThree.Invoke(c, new object[] { src.radius, src.radius, src.height });
           else
@@ -745,7 +790,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
         case VRCPhysBoneColliderBase.ShapeType.Plane:
         {
           var existingMc2PlaneGO = FindExistingConvertedGO(effectiveRoot, src, mc2PlaneType);
-          var newGO = existingMc2PlaneGO ?? CreateChildGameObject(src.gameObject.name + "_MC2PlaneCollider", effectiveRoot);
+          var newGO =
+            existingMc2PlaneGO ?? CreateChildGameObject(src.gameObject.name + "_MC2PlaneCollider", effectiveRoot);
           // MC2 uses the GO's Y+ axis as the plane normal — apply the VRC rotation so
           // the Y+ of this child GO matches the intended plane normal direction.
           newGO.transform.localRotation = src.rotation;
@@ -780,7 +826,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
   /// the source of the conversion, allowing the UI to filter the
   /// "Existing converted colliders" list to only show relevant entries.
   /// </summary>
-  [AddComponentMenu("")]  // hide from the Add Component menu
+  [AddComponentMenu("")] // hide from the Add Component menu
   public class CVRFuryConvertedColliderMarker : MonoBehaviour
   {
     public VRCPhysBoneCollider sourceCollider;

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Editors/VRCPhysBoneColliderEditor.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Editors/VRCPhysBoneColliderEditor.cs
@@ -151,6 +151,23 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
     }
 
     // -------------------------------------------------------------------------
+    // Returns true if at least one converted-collider GO owned by src already
+    // exists under effectiveRoot, used to set the initial Convert button label.
+    // -------------------------------------------------------------------------
+
+    private static bool HasAnyExistingConversions(
+      Transform effectiveRoot, VRCPhysBoneCollider src,
+      Type dbType, Type[] mc1Types, Type[] mc2Types)
+    {
+      if (dbType != null && FindExistingConvertedGO(effectiveRoot, src, dbType) != null) return true;
+      foreach (var t in mc1Types)
+        if (t != null && FindExistingConvertedGO(effectiveRoot, src, t) != null) return true;
+      foreach (var t in mc2Types)
+        if (t != null && FindExistingConvertedGO(effectiveRoot, src, t) != null) return true;
+      return false;
+    }
+
+    // -------------------------------------------------------------------------
     // Existing-conversions UI section
     // Clears then repopulates a persistent container with clickable navigation
     // buttons for each already-converted collider found under effectiveRoot.
@@ -370,7 +387,12 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       root.Add(mc2Toggle);
 
       // -- Convert button --
-      var convertButton = new Button { text = "Convert" };
+      // Label is "Re-Convert" if any conversions already exist for this source collider.
+      bool hasExistingConversions = HasAnyExistingConversions(
+        effectiveRoot, src, dbType,
+        new[] { mc1SphereType, mc1CapsuleType, mc1PlaneType },
+        new[] { mc2SphereType, mc2CapsuleType, mc2PlaneType });
+      var convertButton = new Button { text = hasExistingConversions ? "Re-Convert" : "Convert" };
       convertButton.AddToClassList(CSS_CVR_FURY_BUTTON);
       convertButton.style.marginTop = new StyleLength(6);
 
@@ -471,6 +493,9 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
           new[] { capturedMc1SphereType, capturedMc1CapsuleType, capturedMc1PlaneType },
           new[] { capturedMc2SphereType, capturedMc2CapsuleType, capturedMc2PlaneType }
         );
+
+        // Update button label now that at least one conversion exists
+        convertButton.text = "Re-Convert";
       };
 
       root.Add(convertButton);

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Editors/VRCPhysBoneColliderEditor.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Editors/VRCPhysBoneColliderEditor.cs
@@ -142,6 +142,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
 
     private static void PopulateExistingConversions(
       VisualElement container,
+      VRCPhysBoneCollider src,
       Transform effectiveRoot,
       Type dbType,
       Type[] mc1Types,
@@ -151,25 +152,37 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
 
       var found = new List<(string label, Component comp)>();
 
-      // DynamicBone
+      // DynamicBone — only include GOs whose marker references this src collider
       if (dbType != null)
         foreach (Component c in effectiveRoot.GetComponentsInChildren(dbType, true))
-          found.Add(($"DynamicBoneCollider on \"{c.gameObject.name}\"", c));
+        {
+          var marker = c.GetComponent<CVRFuryConvertedColliderMarker>();
+          if (marker != null && marker.sourceCollider == src)
+            found.Add(($"DynamicBoneCollider on \"{c.gameObject.name}\"", c));
+        }
 
-      // MagicaCloth 1
+      // MagicaCloth 1 — only include GOs whose marker references this src collider
       foreach (var t in mc1Types)
       {
         if (t == null) continue;
         foreach (Component c in effectiveRoot.GetComponentsInChildren(t, true))
-          found.Add(($"{t.Name} (MC1) on \"{c.gameObject.name}\"", c));
+        {
+          var marker = c.GetComponent<CVRFuryConvertedColliderMarker>();
+          if (marker != null && marker.sourceCollider == src)
+            found.Add(($"{t.Name} (MC1) on \"{c.gameObject.name}\"", c));
+        }
       }
 
-      // MagicaCloth 2
+      // MagicaCloth 2 — only include GOs whose marker references this src collider
       foreach (var t in mc2Types)
       {
         if (t == null) continue;
         foreach (Component c in effectiveRoot.GetComponentsInChildren(t, true))
-          found.Add(($"{t.Name} (MC2) on \"{c.gameObject.name}\"", c));
+        {
+          var marker = c.GetComponent<CVRFuryConvertedColliderMarker>();
+          if (marker != null && marker.sourceCollider == src)
+            found.Add(($"{t.Name} (MC2) on \"{c.gameObject.name}\"", c));
+        }
       }
 
       // Leave container empty (invisible) when nothing found
@@ -289,6 +302,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       root.Add(existingContainer);
       PopulateExistingConversions(
         existingContainer,
+        src,
         effectiveRoot,
         dbType,
         new[] { mc1SphereType, mc1CapsuleType, mc1PlaneType },
@@ -433,6 +447,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
         // appear without the user needing to deselect and reselect the object.
         PopulateExistingConversions(
           capturedExistingContainer,
+          src,
           capturedEffectiveRoot,
           capturedDbType,
           new[] { capturedMc1SphereType, capturedMc1CapsuleType, capturedMc1PlaneType },
@@ -505,6 +520,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       if (bndProp != null) bndProp.enumValueIndex = src.insideBounds ? 1 : 0; // 0=Outside 1=Inside
 
       so.ApplyModifiedProperties();
+      var dbMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+      dbMarker.sourceCollider = src;
       EditorUtility.SetDirty(newGO);
     }
 
@@ -532,6 +549,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
           var c = ObjectFactory.AddComponent(newGO, mc1SphereType);
           SetProp(c, "Radius", src.radius);
           SetProp(c, "Center", src.position);
+          var mc1SphereMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+          mc1SphereMarker.sourceCollider = src;
           EditorUtility.SetDirty(newGO);
           addedName = "MagicaSphereCollider (MC1)";
           break;
@@ -561,6 +580,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
           SetProp(c, "StartRadius", src.radius);
           SetProp(c, "EndRadius",   src.radius);
           SetProp(c, "Center",      src.position);
+          var mc1CapsMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+          mc1CapsMarker.sourceCollider = src;
           EditorUtility.SetDirty(newGO);
           addedName = "MagicaCapsuleCollider (MC1)";
           break;
@@ -573,6 +594,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
           newGO.transform.localRotation = src.rotation;
           var c = ObjectFactory.AddComponent(newGO, mc1PlaneType);
           SetProp(c, "Center", src.position);
+          var mc1PlaneMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+          mc1PlaneMarker.sourceCollider = src;
           EditorUtility.SetDirty(newGO);
           addedName = "MagicaPlaneCollider (MC1)";
           break;
@@ -614,6 +637,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
           else
             SetField(c, "size", new Vector3(src.radius, 0f, 0f)); // fallback
 
+          var mc2SphereMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+          mc2SphereMarker.sourceCollider = src;
           EditorUtility.SetDirty(newGO);
           addedName = "MagicaSphereCollider (MC2)";
           break;
@@ -644,6 +669,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
           else
             SetField(c, "size", new Vector3(src.radius, src.radius, src.height)); // fallback
 
+          var mc2CapsMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+          mc2CapsMarker.sourceCollider = src;
           EditorUtility.SetDirty(newGO);
           addedName = "MagicaCapsuleCollider (MC2)";
           break;
@@ -656,6 +683,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
           newGO.transform.localRotation = src.rotation;
           var c = ObjectFactory.AddComponent(newGO, mc2PlaneType);
           SetField(c, "center", src.position);
+          var mc2PlaneMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+          mc2PlaneMarker.sourceCollider = src;
           EditorUtility.SetDirty(newGO);
           addedName = "MagicaPlaneCollider (MC2)";
           break;
@@ -666,5 +695,23 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
 
       return addedName;
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Marker component — tracks which VRCPhysBoneCollider owns each converted
+  // collider child GO, so the Inspector UI can filter to show only the
+  // conversions owned by the currently-inspected collider component.
+  // -------------------------------------------------------------------------
+
+  /// <summary>
+  /// Lightweight marker attached to every converted-collider child GameObject.
+  /// The sourceCollider field points back to the VRCPhysBoneCollider that was
+  /// the source of the conversion, allowing the UI to filter the
+  /// "Existing converted colliders" list to only show relevant entries.
+  /// </summary>
+  [AddComponentMenu("")]  // hide from the Add Component menu
+  public class CVRFuryConvertedColliderMarker : MonoBehaviour
+  {
+    public VRCPhysBoneCollider sourceCollider;
   }
 }

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Editors/VRCPhysBoneColliderEditor.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Editors/VRCPhysBoneColliderEditor.cs
@@ -133,6 +133,24 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
     }
 
     // -------------------------------------------------------------------------
+    // Find an existing converted-collider GO owned by the given source collider
+    // that already has a component of targetType. Returns null if none found.
+    // Used by the conversion methods to update in place instead of duplicating.
+    // -------------------------------------------------------------------------
+
+    private static GameObject FindExistingConvertedGO(
+      Transform effectiveRoot, VRCPhysBoneCollider src, Type targetType)
+    {
+      foreach (Component c in effectiveRoot.GetComponentsInChildren(targetType, true))
+      {
+        var marker = c.GetComponent<CVRFuryConvertedColliderMarker>();
+        if (marker != null && marker.sourceCollider == src)
+          return c.gameObject;
+      }
+      return null;
+    }
+
+    // -------------------------------------------------------------------------
     // Existing-conversions UI section
     // Clears then repopulates a persistent container with clickable navigation
     // buttons for each already-converted collider found under effectiveRoot.
@@ -494,7 +512,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
         return;
       }
 
-      var newGO = CreateChildGameObject(src.gameObject.name + "_DBCollider", effectiveRoot);
+      var existingDbGO = FindExistingConvertedGO(effectiveRoot, src, dbType);
+      var newGO = existingDbGO ?? CreateChildGameObject(src.gameObject.name + "_DBCollider", effectiveRoot);
 
       // VRC capsule extends along its Y-axis; apply the VRC rotation to the child GO
       // so that direction Y on the DynamicBoneCollider aligns with the intended capsule axis.
@@ -502,8 +521,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       if (src.shapeType == VRCPhysBoneColliderBase.ShapeType.Capsule)
         newGO.transform.localRotation = src.rotation;
 
-      var dbc   = ObjectFactory.AddComponent(newGO, dbType);
-      var so    = new SerializedObject(dbc);
+      var dbc = newGO.GetComponent(dbType) ?? ObjectFactory.AddComponent(newGO, dbType);
+      var so  = new SerializedObject(dbc);
 
       var radProp = so.FindProperty("m_Radius");
       var hProp   = so.FindProperty("m_Height");
@@ -520,8 +539,11 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       if (bndProp != null) bndProp.enumValueIndex = src.insideBounds ? 1 : 0; // 0=Outside 1=Inside
 
       so.ApplyModifiedProperties();
-      var dbMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-      dbMarker.sourceCollider = src;
+      if (existingDbGO == null)
+      {
+        var dbMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+        dbMarker.sourceCollider = src;
+      }
       EditorUtility.SetDirty(newGO);
     }
 
@@ -545,23 +567,28 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       {
         case VRCPhysBoneColliderBase.ShapeType.Sphere:
         {
-          var newGO = CreateChildGameObject(src.gameObject.name + "_MC1SphereCollider", effectiveRoot);
-          var c = ObjectFactory.AddComponent(newGO, mc1SphereType);
+          var existingMc1SphereGO = FindExistingConvertedGO(effectiveRoot, src, mc1SphereType);
+          var newGO = existingMc1SphereGO ?? CreateChildGameObject(src.gameObject.name + "_MC1SphereCollider", effectiveRoot);
+          var c = newGO.GetComponent(mc1SphereType) ?? ObjectFactory.AddComponent(newGO, mc1SphereType);
           SetProp(c, "Radius", src.radius);
           SetProp(c, "Center", src.position);
-          var mc1SphereMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-          mc1SphereMarker.sourceCollider = src;
+          if (existingMc1SphereGO == null)
+          {
+            var mc1SphereMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+            mc1SphereMarker.sourceCollider = src;
+          }
           EditorUtility.SetDirty(newGO);
           addedName = "MagicaSphereCollider (MC1)";
           break;
         }
         case VRCPhysBoneColliderBase.ShapeType.Capsule:
         {
-          var newGO = CreateChildGameObject(src.gameObject.name + "_MC1CapsuleCollider", effectiveRoot);
+          var existingMc1CapsGO = FindExistingConvertedGO(effectiveRoot, src, mc1CapsuleType);
+          var newGO = existingMc1CapsGO ?? CreateChildGameObject(src.gameObject.name + "_MC1CapsuleCollider", effectiveRoot);
           // VRC capsule extends along its Y-axis; apply VRC rotation to the child GO
           // so the GO's local Y aligns with the intended capsule axis.
           newGO.transform.localRotation = src.rotation;
-          var c = ObjectFactory.AddComponent(newGO, mc1CapsuleType);
+          var c = newGO.GetComponent(mc1CapsuleType) ?? ObjectFactory.AddComponent(newGO, mc1CapsuleType);
 
           // AxisMode: always Y (1) — VRC's natural capsule axis is Y; orientation carried by GO's rotation.
           var axisEnumType = GetNestedTypeDeep(mc1CapsuleType, "Axis");
@@ -580,22 +607,29 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
           SetProp(c, "StartRadius", src.radius);
           SetProp(c, "EndRadius",   src.radius);
           SetProp(c, "Center",      src.position);
-          var mc1CapsMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-          mc1CapsMarker.sourceCollider = src;
+          if (existingMc1CapsGO == null)
+          {
+            var mc1CapsMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+            mc1CapsMarker.sourceCollider = src;
+          }
           EditorUtility.SetDirty(newGO);
           addedName = "MagicaCapsuleCollider (MC1)";
           break;
         }
         case VRCPhysBoneColliderBase.ShapeType.Plane:
         {
-          var newGO = CreateChildGameObject(src.gameObject.name + "_MC1PlaneCollider", effectiveRoot);
+          var existingMc1PlaneGO = FindExistingConvertedGO(effectiveRoot, src, mc1PlaneType);
+          var newGO = existingMc1PlaneGO ?? CreateChildGameObject(src.gameObject.name + "_MC1PlaneCollider", effectiveRoot);
           // MC1 uses the GO's Y+ axis as the plane normal — apply the VRC rotation so
           // the Y+ of this child GO matches the intended plane normal direction.
           newGO.transform.localRotation = src.rotation;
-          var c = ObjectFactory.AddComponent(newGO, mc1PlaneType);
+          var c = newGO.GetComponent(mc1PlaneType) ?? ObjectFactory.AddComponent(newGO, mc1PlaneType);
           SetProp(c, "Center", src.position);
-          var mc1PlaneMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-          mc1PlaneMarker.sourceCollider = src;
+          if (existingMc1PlaneGO == null)
+          {
+            var mc1PlaneMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+            mc1PlaneMarker.sourceCollider = src;
+          }
           EditorUtility.SetDirty(newGO);
           addedName = "MagicaPlaneCollider (MC1)";
           break;
@@ -626,8 +660,9 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       {
         case VRCPhysBoneColliderBase.ShapeType.Sphere:
         {
-          var newGO = CreateChildGameObject(src.gameObject.name + "_MC2SphereCollider", effectiveRoot);
-          var c = ObjectFactory.AddComponent(newGO, mc2SphereType);
+          var existingMc2SphereGO = FindExistingConvertedGO(effectiveRoot, src, mc2SphereType);
+          var newGO = existingMc2SphereGO ?? CreateChildGameObject(src.gameObject.name + "_MC2SphereCollider", effectiveRoot);
+          var c = newGO.GetComponent(mc2SphereType) ?? ObjectFactory.AddComponent(newGO, mc2SphereType);
           SetField(c, "center", src.position);
 
           // MagicaSphereCollider.SetSize(float radius) sets size = new Vector3(r,0,0)
@@ -637,19 +672,23 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
           else
             SetField(c, "size", new Vector3(src.radius, 0f, 0f)); // fallback
 
-          var mc2SphereMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-          mc2SphereMarker.sourceCollider = src;
+          if (existingMc2SphereGO == null)
+          {
+            var mc2SphereMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+            mc2SphereMarker.sourceCollider = src;
+          }
           EditorUtility.SetDirty(newGO);
           addedName = "MagicaSphereCollider (MC2)";
           break;
         }
         case VRCPhysBoneColliderBase.ShapeType.Capsule:
         {
-          var newGO = CreateChildGameObject(src.gameObject.name + "_MC2CapsuleCollider", effectiveRoot);
+          var existingMc2CapsGO = FindExistingConvertedGO(effectiveRoot, src, mc2CapsuleType);
+          var newGO = existingMc2CapsGO ?? CreateChildGameObject(src.gameObject.name + "_MC2CapsuleCollider", effectiveRoot);
           // VRC capsule extends along its Y-axis; apply VRC rotation to the child GO
           // so the GO's local Y aligns with the intended capsule axis.
           newGO.transform.localRotation = src.rotation;
-          var c = ObjectFactory.AddComponent(newGO, mc2CapsuleType);
+          var c = newGO.GetComponent(mc2CapsuleType) ?? ObjectFactory.AddComponent(newGO, mc2CapsuleType);
           SetField(c, "center", src.position);
 
           // Direction: always Y (1) — VRC's natural capsule axis is Y; orientation carried by GO's rotation.
@@ -669,22 +708,29 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
           else
             SetField(c, "size", new Vector3(src.radius, src.radius, src.height)); // fallback
 
-          var mc2CapsMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-          mc2CapsMarker.sourceCollider = src;
+          if (existingMc2CapsGO == null)
+          {
+            var mc2CapsMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+            mc2CapsMarker.sourceCollider = src;
+          }
           EditorUtility.SetDirty(newGO);
           addedName = "MagicaCapsuleCollider (MC2)";
           break;
         }
         case VRCPhysBoneColliderBase.ShapeType.Plane:
         {
-          var newGO = CreateChildGameObject(src.gameObject.name + "_MC2PlaneCollider", effectiveRoot);
+          var existingMc2PlaneGO = FindExistingConvertedGO(effectiveRoot, src, mc2PlaneType);
+          var newGO = existingMc2PlaneGO ?? CreateChildGameObject(src.gameObject.name + "_MC2PlaneCollider", effectiveRoot);
           // MC2 uses the GO's Y+ axis as the plane normal — apply the VRC rotation so
           // the Y+ of this child GO matches the intended plane normal direction.
           newGO.transform.localRotation = src.rotation;
-          var c = ObjectFactory.AddComponent(newGO, mc2PlaneType);
+          var c = newGO.GetComponent(mc2PlaneType) ?? ObjectFactory.AddComponent(newGO, mc2PlaneType);
           SetField(c, "center", src.position);
-          var mc2PlaneMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-          mc2PlaneMarker.sourceCollider = src;
+          if (existingMc2PlaneGO == null)
+          {
+            var mc2PlaneMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+            mc2PlaneMarker.sourceCollider = src;
+          }
           EditorUtility.SetDirty(newGO);
           addedName = "MagicaPlaneCollider (MC2)";
           break;

--- a/docs/physbone-collider-converter.md
+++ b/docs/physbone-collider-converter.md
@@ -1,0 +1,204 @@
+# PhysBone Collider Converter
+
+Convert VRCPhysBoneCollider components to CVR-compatible colliders (DynamicBone,
+MagicaCloth 1, MagicaCloth 2) directly from the Unity Inspector.
+
+---
+
+## Status
+
+Implemented and live in the custom inspector.
+
+This document reflects current behavior:
+
+- Existing converted colliders are scoped to the current source collider only.
+- Repeated conversions update existing owned colliders in place (no duplicate stacking).
+- Convert button label changes to Re-Convert when owned conversions already exist.
+- Removing the source VRC PhysBone Collider also removes its owned marker components.
+
+---
+
+## File Location
+
+Primary implementation file:
+
+- CVRFury-Compiled-Components/VRCStubConvertAndUI/VRCPBUIAndConverter/Editors/VRCPhysBoneColliderEditor.cs
+
+---
+
+## Runtime Package Detection
+
+Because this editor is compiled into a precompiled DLL, package support is detected at runtime via type lookup:
+
+- DynamicBoneCollider
+- MagicaCloth.MagicaSphereCollider / MagicaCapsuleCollider / MagicaPlaneCollider
+- MagicaCloth2.MagicaSphereCollider / MagicaCapsuleCollider / MagicaPlaneCollider
+
+No compile-time per-project define guards are required for the conversion logic.
+
+---
+
+## Inspector UI Behavior
+
+The inspector shows:
+
+1. Shape and root transform info.
+2. Existing converted colliders list (clickable entries).
+3. Convert toggles:
+   - Dynamic Bone Collider
+   - MagicaCloth 1 Collider
+   - MagicaCloth 2 Collider
+4. Convert or Re-Convert button.
+5. Remove VRC PhysBone Collider Component button.
+
+### Toggle rules
+
+- Dynamic Bone toggle is disabled when package is missing.
+- Dynamic Bone toggle is also disabled for Plane shape.
+- MC1 and MC2 toggles are disabled when required collider types are missing.
+
+### Convert button label
+
+- Shows Convert when no owned converted colliders exist for this source.
+- Shows Re-Convert when at least one owned converted collider exists.
+- After a successful conversion pass, label is set to Re-Convert.
+
+---
+
+## Ownership Marker System
+
+A lightweight marker component is attached to converted collider GameObjects:
+
+- Type: CVRFuryConvertedColliderMarker
+- Field: sourceCollider (VRCPhysBoneCollider reference)
+
+Purpose:
+
+- Associate each converted collider with the exact source collider that created it.
+- Prevent cross-contamination in the Existing converted colliders panel.
+- Enable in-place reconversion updates and safe cleanup.
+
+### Existing conversions panel filtering
+
+The panel only shows converted colliders where:
+
+- Component type matches DB/MC1/MC2 collider type, and
+- Marker exists, and
+- marker.sourceCollider equals the currently inspected VRCPhysBoneCollider.
+
+So even if multiple converted sets exist under the same hierarchy, only the relevant set is displayed.
+
+---
+
+## Conversion Strategy (Current)
+
+All conversion paths now use update-or-create behavior:
+
+1. Search for an existing owned converted collider GameObject under effective root.
+2. If found, reuse it and update fields.
+3. If not found, create a new child GameObject and add the target collider component.
+4. Attach ownership marker only on first creation.
+
+This is implemented through helper methods that locate existing owned conversions by marker + target type.
+
+---
+
+## Effective Root and Placement
+
+Effective root is:
+
+- src.rootTransform when set, otherwise
+- src.transform
+
+Converted collider GameObjects live under the effective root.
+
+Naming convention for newly created objects:
+
+- {sourceName}_DBCollider
+- {sourceName}_MC1SphereCollider
+- {sourceName}_MC1CapsuleCollider
+- {sourceName}_MC1PlaneCollider
+- {sourceName}_MC2SphereCollider
+- {sourceName}_MC2CapsuleCollider
+- {sourceName}_MC2PlaneCollider
+
+Note: during reconvert/update, existing names are preserved.
+
+---
+
+## Shape Mapping Details
+
+### DynamicBone
+
+- Plane is not supported.
+- Radius maps to m_Radius.
+- Capsule height maps to m_Height (sphere uses 0).
+- Center maps to m_Center.
+- Bound maps from insideBounds.
+- Direction is fixed to Y axis (enum index 1).
+- For capsule, child local rotation is set from source rotation.
+
+### MagicaCloth 1
+
+- Sphere: Radius and Center set via properties.
+- Capsule:
+  - AxisMode fixed to Y.
+  - Uses half-length model: max(src.height / 2 - src.radius, 0), clamped to [0,1].
+  - StartRadius and EndRadius set from source radius.
+  - Center set from source position.
+  - Warning emitted when half-length exceeds 1.0.
+- Plane: Center set; local rotation copied from source for normal alignment.
+
+### MagicaCloth 2
+
+- Sphere:
+  - center field set.
+  - SetSize(float radius) used when available.
+- Capsule:
+  - center field set.
+  - direction fixed to Y.
+  - radiusSeparation set false.
+  - alignedOnCenter set true.
+  - SetSize(startRadius, endRadius, length) used when available.
+  - local rotation copied from source.
+- Plane:
+  - center field set.
+  - local rotation copied from source for normal alignment.
+
+---
+
+## Warnings and Dialogs
+
+Convert/Re-Convert action shows summary dialog listing selected conversion targets.
+
+Additional warnings are shown when applicable:
+
+- insideBounds with MC1/MC2 (outside mode approximation)
+- Plane orientation verification note for MC1/MC2
+- MC1 capsule half-length clamped note when required
+
+---
+
+## Remove Button Behavior
+
+Remove VRC PhysBone Collider Component now performs cleanup before source removal:
+
+1. Finds all CVRFuryConvertedColliderMarker components under effective root.
+2. Removes markers whose sourceCollider matches the source being removed.
+3. Removes the source VRC PhysBone Collider component itself.
+
+This prevents stale ownership markers from remaining after source deletion.
+
+---
+
+## Functional Summary
+
+Current converter behavior is:
+
+- Type-safe runtime package detection
+- Scoped existing-conversions listing per source collider ownership
+- Update-in-place reconversion (no repeated duplicate sets)
+- Dynamic Convert/Re-Convert button labeling
+- Marker cleanup on source removal
+
+This is the intended baseline for future collider-converter enhancements.


### PR DESCRIPTION
## In this merge:

- Added ownership tracking for converted colliders using a lightweight source marker
- Updated Existing converted colliders UI to only show colliders owned by the currently selected source collider
- Added update-in-place conversion flow so pressing Convert again updates existing owned colliders instead of creating duplicates
- Added dynamic button label behavior: Convert switches to Re-Convert when owned conversions already exist
- Updated remove behavior so deleting the source VRC PhysBone Collider also removes its now-orphaned ownership markers
- Updated physbone-collider-converter.md to fully match implemented behavior and current converter architecture

## Notes

This makes the inspector conversion workflow much clearer and safer for end users when working with multiple collider sets in the same hierarchy.

The converter now behaves predictably for repeated runs:
- No more duplicate collider stacking from repeated Convert clicks
- Existing converted colliders list is scoped correctly to the active source collider
- Marker cleanup prevents stale ownership metadata after source removal

Net result: cleaner hierarchy output, less manual cleanup, and a more reliable re-conversion workflow.