### PR TITLE
Refactor conversion architecture: expose shared contact, collider, and constraint APIs for mass tooling

### DIFF
--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/APIVersion.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/APIVersion.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace uk.novavoidhowl.dev.cvrfury.compiled.vrccolliders
+{
+  public static class APIVersion
+  {
+    private static readonly Version _version = new Version(1, 0, 0);
+
+    public static string CurrentVersion
+    {
+      get { return _version.ToString(); }
+    }
+
+    public static Version AsVersion
+    {
+      get { return _version; }
+    }
+
+    public static bool IsVersionAtLeast(Version otherVersion)
+    {
+      return _version.CompareTo(otherVersion) >= 0;
+    }
+
+    public static bool IsVersionAtLeast(string otherVersion)
+    {
+      return IsVersionAtLeast(new Version(otherVersion));
+    }
+  }
+}

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/UIVersion.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Common/UIVersion.cs
@@ -4,7 +4,7 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors.Common
 {
   public static class UIVersion
   {
-    private static readonly Version _version = new Version(2, 2, 1);
+    private static readonly Version _version = new Version(2, 3, 0);
 
     public static string CurrentVersion => _version.ToString();
     public static Version AsVersion => _version;

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Conversion/VRCPhysBoneColliderConversionActions.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Conversion/VRCPhysBoneColliderConversionActions.cs
@@ -1,0 +1,529 @@
+using System;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+using VRC.Dynamics;
+using VRC.SDK3.Dynamics.PhysBone.Components;
+using VRC.SDK3.Dynamics.PhysBone.Editors;
+
+namespace uk.novavoidhowl.dev.cvrfury.compiled.vrccolliders
+{
+  public static class VRCPhysBoneColliderConversionActions
+  {
+    public static string ApiVersion
+    {
+      get { return APIVersion.CurrentVersion; }
+    }
+
+    public static Version ApiVersionAsVersion
+    {
+      get { return APIVersion.AsVersion; }
+    }
+
+    public static bool IsApiVersionAtLeast(Version otherVersion)
+    {
+      return APIVersion.IsVersionAtLeast(otherVersion);
+    }
+
+    public static bool IsApiVersionAtLeast(string otherVersion)
+    {
+      return APIVersion.IsVersionAtLeast(otherVersion);
+    }
+
+    public static VRCPhysBoneColliderConversionAvailability GetAvailability(VRCPhysBoneCollider source)
+    {
+      var types = DetectTargetTypes();
+      bool isPlane = source != null && source.shapeType == VRCPhysBoneColliderBase.ShapeType.Plane;
+
+      var availability = new VRCPhysBoneColliderConversionAvailability
+      {
+        CanConvertDynamicBone = types.dbType != null && !isPlane,
+        CanConvertMagicaCloth1 = types.mc1SphereType != null && types.mc1CapsuleType != null && types.mc1PlaneType != null,
+        CanConvertMagicaCloth2 = types.mc2SphereType != null && types.mc2CapsuleType != null && types.mc2PlaneType != null
+      };
+
+      if (types.dbType == null)
+        availability.Messages.Add(new ConversionMessage(ConversionMessageSeverity.Info, "dynamic_bone_missing", "DynamicBone package not detected."));
+      else if (isPlane)
+        availability.Messages.Add(new ConversionMessage(ConversionMessageSeverity.Info, "dynamic_bone_plane_unsupported", "DynamicBone does not support Plane colliders."));
+
+      if (!availability.CanConvertMagicaCloth1)
+        availability.Messages.Add(new ConversionMessage(ConversionMessageSeverity.Info, "magica_cloth_1_missing", "MagicaCloth 1 package not detected."));
+
+      if (!availability.CanConvertMagicaCloth2)
+        availability.Messages.Add(new ConversionMessage(ConversionMessageSeverity.Info, "magica_cloth_2_missing", "MagicaCloth 2 package not detected."));
+
+      return availability;
+    }
+
+    public static VRCPhysBoneColliderConversionGuidance GetGuidance(
+      VRCPhysBoneCollider source,
+      PhysBoneColliderTarget targets
+    )
+    {
+      var guidance = new VRCPhysBoneColliderConversionGuidance();
+
+      guidance.Messages.Add(
+        new ConversionMessage(
+          ConversionMessageSeverity.Info,
+          "collider_reconvert_updates_owned",
+          "PhysBone collider conversion updates existing owned converted colliders in place when marker ownership matches the source collider."
+        )
+      );
+
+      if (source != null && source.insideBounds && HasTarget(targets, PhysBoneColliderTarget.MagicaCloth1 | PhysBoneColliderTarget.MagicaCloth2))
+      {
+        guidance.Messages.Add(
+          new ConversionMessage(
+            ConversionMessageSeverity.Warning,
+            "inside_bounds_magica_approximation",
+            "Inside-bounds is not supported by MagicaCloth. Outside mode is applied for MC1/MC2."
+          )
+        );
+      }
+
+      if (source != null && source.shapeType == VRCPhysBoneColliderBase.ShapeType.Plane && HasTarget(targets, PhysBoneColliderTarget.MagicaCloth1 | PhysBoneColliderTarget.MagicaCloth2))
+      {
+        guidance.Messages.Add(
+          new ConversionMessage(
+            ConversionMessageSeverity.Warning,
+            "plane_orientation_check",
+            "Plane conversion applies the VRC rotation to the child GameObject. Verify the orientation in the Scene view."
+          )
+        );
+      }
+
+      return guidance;
+    }
+
+    public static VRCPhysBoneColliderConversionResult Convert(
+      VRCPhysBoneCollider source,
+      PhysBoneColliderTarget targets,
+      VRCPhysBoneColliderConversionOptions options
+    )
+    {
+      if (source == null)
+        return VRCPhysBoneColliderConversionResult.Failed("PhysBone Collider Conversion Failed", "Source collider is missing.", "missing_source");
+
+      if (options == null)
+        options = VRCPhysBoneColliderConversionOptions.ForInspector();
+
+      var types = DetectTargetTypes();
+      var effectiveRoot = source.rootTransform != null ? source.rootTransform : source.transform;
+      var result = new VRCPhysBoneColliderConversionResult
+      {
+        SummaryTitle = "PhysBone Collider Converted",
+        EffectiveRoot = effectiveRoot
+      };
+
+      foreach (var message in GetGuidance(source, targets).Messages)
+        result.Messages.Add(message);
+
+      if (targets == PhysBoneColliderTarget.None)
+      {
+        const string message = "No collider conversion targets were selected.";
+        result.Messages.Add(new ConversionMessage(ConversionMessageSeverity.Error, "no_targets_selected", message));
+        result.SummaryMessage = message;
+        return result;
+      }
+
+      if (HasTarget(targets, PhysBoneColliderTarget.DynamicBone))
+      {
+        if (types.dbType == null)
+          AddError(result, "dynamic_bone_missing", "DynamicBoneCollider type was not found. Dynamic Bone conversion was skipped.");
+        else if (source.shapeType == VRCPhysBoneColliderBase.ShapeType.Plane)
+          AddError(result, "dynamic_bone_plane_unsupported", "DynamicBone does not support Plane colliders. Dynamic Bone conversion was skipped.");
+        else
+        {
+          var convertedObject = ConvertToDynamicBone(source, types.dbType, effectiveRoot);
+          result.ConvertedTargets.Add("DynamicBoneCollider");
+          result.CreatedOrUpdatedObjects.Add(convertedObject);
+        }
+      }
+
+      if (HasTarget(targets, PhysBoneColliderTarget.MagicaCloth1))
+      {
+        if (types.mc1SphereType == null || types.mc1CapsuleType == null || types.mc1PlaneType == null)
+          AddError(result, "magica_cloth_1_missing", "MagicaCloth 1 collider types were not found. MC1 conversion was skipped.");
+        else
+        {
+          string warning;
+          GameObject convertedObject;
+          string mc1Name = ConvertToMagicaCloth1(
+            source,
+            types.mc1SphereType,
+            types.mc1CapsuleType,
+            types.mc1PlaneType,
+            effectiveRoot,
+            out warning,
+            out convertedObject
+          );
+          result.ConvertedTargets.Add(mc1Name);
+          result.CreatedOrUpdatedObjects.Add(convertedObject);
+          if (warning != null)
+            result.Messages.Add(new ConversionMessage(ConversionMessageSeverity.Warning, "magica_cloth_1_capsule_clamped", warning));
+        }
+      }
+
+      if (HasTarget(targets, PhysBoneColliderTarget.MagicaCloth2))
+      {
+        if (types.mc2SphereType == null || types.mc2CapsuleType == null || types.mc2PlaneType == null)
+          AddError(result, "magica_cloth_2_missing", "MagicaCloth 2 collider types were not found. MC2 conversion was skipped.");
+        else
+        {
+          GameObject convertedObject;
+          string mc2Name = ConvertToMagicaCloth2(
+            source,
+            types.mc2SphereType,
+            types.mc2CapsuleType,
+            types.mc2PlaneType,
+            effectiveRoot,
+            out convertedObject
+          );
+          result.ConvertedTargets.Add(mc2Name);
+          result.CreatedOrUpdatedObjects.Add(convertedObject);
+        }
+      }
+
+      result.Success = result.ConvertedTargets.Count > 0;
+      result.SummaryMessage = BuildSummaryMessage(result);
+      return result;
+    }
+
+    private static bool HasTarget(PhysBoneColliderTarget targets, PhysBoneColliderTarget target)
+    {
+      return (targets & target) != 0;
+    }
+
+    private static void AddError(VRCPhysBoneColliderConversionResult result, string code, string message)
+    {
+      Debug.LogError("[CVRFury] " + message);
+      result.Messages.Add(new ConversionMessage(ConversionMessageSeverity.Error, code, message));
+    }
+
+    private static string BuildSummaryMessage(VRCPhysBoneColliderConversionResult result)
+    {
+      if (!result.Success)
+        return "No PhysBone collider conversions were completed.";
+
+      return "Created or updated child GameObjects under \""
+        + result.EffectiveRoot.name
+        + "\":\n"
+        + string.Join(", ", result.ConvertedTargets.ToArray());
+    }
+
+    private static TargetTypes DetectTargetTypes()
+    {
+      return new TargetTypes(
+        FindType("DynamicBoneCollider"),
+        FindType("MagicaCloth.MagicaSphereCollider"),
+        FindType("MagicaCloth.MagicaCapsuleCollider"),
+        FindType("MagicaCloth.MagicaPlaneCollider"),
+        FindType("MagicaCloth2.MagicaSphereCollider"),
+        FindType("MagicaCloth2.MagicaCapsuleCollider"),
+        FindType("MagicaCloth2.MagicaPlaneCollider")
+      );
+    }
+
+    private static Type FindType(string fullTypeName)
+    {
+      foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+      {
+        var t = asm.GetType(fullTypeName);
+        if (t != null)
+          return t;
+      }
+      return null;
+    }
+
+    private static void SetProp(object obj, string name, object value)
+    {
+      var type = obj.GetType();
+      while (type != null)
+      {
+        var prop = type.GetProperty(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+        if (prop != null && prop.CanWrite)
+        {
+          prop.SetValue(obj, value);
+          return;
+        }
+        type = type.BaseType;
+      }
+      Debug.LogWarning("[CVRFury] Property '" + name + "' not found on " + obj.GetType().FullName);
+    }
+
+    private static void SetField(object obj, string name, object value)
+    {
+      var type = obj.GetType();
+      while (type != null)
+      {
+        var field = type.GetField(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+        if (field != null)
+        {
+          field.SetValue(obj, value);
+          return;
+        }
+        type = type.BaseType;
+      }
+      Debug.LogWarning("[CVRFury] Field '" + name + "' not found on " + obj.GetType().FullName);
+    }
+
+    private static Type GetNestedTypeDeep(Type type, string nestedName)
+    {
+      while (type != null)
+      {
+        var nested = type.GetNestedType(nestedName, BindingFlags.Public);
+        if (nested != null)
+          return nested;
+        type = type.BaseType;
+      }
+      return null;
+    }
+
+    private static GameObject CreateChildGameObject(string name, Transform parent)
+    {
+      var go = new GameObject(name);
+      Undo.RegisterCreatedObjectUndo(go, "Create converted collider");
+      go.transform.SetParent(parent, false);
+      go.transform.localPosition = Vector3.zero;
+      go.transform.localRotation = Quaternion.identity;
+      go.transform.localScale = Vector3.one;
+      return go;
+    }
+
+    private static GameObject FindExistingConvertedGO(Transform effectiveRoot, VRCPhysBoneCollider src, Type targetType)
+    {
+      foreach (Component c in effectiveRoot.GetComponentsInChildren(targetType, true))
+      {
+        var marker = c.GetComponent<CVRFuryConvertedColliderMarker>();
+        if (marker != null && marker.sourceCollider == src)
+          return c.gameObject;
+      }
+      return null;
+    }
+
+    private static GameObject ConvertToDynamicBone(VRCPhysBoneCollider src, Type dbType, Transform effectiveRoot)
+    {
+      var existingDbGO = FindExistingConvertedGO(effectiveRoot, src, dbType);
+      var newGO = existingDbGO ?? CreateChildGameObject(src.gameObject.name + "_DBCollider", effectiveRoot);
+
+      if (src.shapeType == VRCPhysBoneColliderBase.ShapeType.Capsule)
+        newGO.transform.localRotation = src.rotation;
+
+      var dbc = newGO.GetComponent(dbType) ?? ObjectFactory.AddComponent(newGO, dbType);
+      var so = new SerializedObject(dbc);
+
+      var radProp = so.FindProperty("m_Radius");
+      var hProp = so.FindProperty("m_Height");
+      var cProp = so.FindProperty("m_Center");
+      var dirProp = so.FindProperty("m_Direction");
+      var bndProp = so.FindProperty("m_Bound");
+
+      if (radProp != null)
+        radProp.floatValue = src.radius;
+      if (hProp != null)
+        hProp.floatValue = src.shapeType == VRCPhysBoneColliderBase.ShapeType.Capsule ? src.height : 0f;
+      if (cProp != null)
+        cProp.vector3Value = src.position;
+      if (dirProp != null)
+        dirProp.enumValueIndex = 1;
+      if (bndProp != null)
+        bndProp.enumValueIndex = src.insideBounds ? 1 : 0;
+
+      so.ApplyModifiedProperties();
+      if (existingDbGO == null)
+      {
+        var dbMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+        dbMarker.sourceCollider = src;
+      }
+      EditorUtility.SetDirty(newGO);
+      return newGO;
+    }
+
+    private static string ConvertToMagicaCloth1(
+      VRCPhysBoneCollider src,
+      Type mc1SphereType,
+      Type mc1CapsuleType,
+      Type mc1PlaneType,
+      Transform effectiveRoot,
+      out string warning,
+      out GameObject convertedObject
+    )
+    {
+      warning = null;
+
+      switch (src.shapeType)
+      {
+        case VRCPhysBoneColliderBase.ShapeType.Sphere:
+        {
+          var existingMc1SphereGO = FindExistingConvertedGO(effectiveRoot, src, mc1SphereType);
+          var newGO = existingMc1SphereGO ?? CreateChildGameObject(src.gameObject.name + "_MC1SphereCollider", effectiveRoot);
+          var c = newGO.GetComponent(mc1SphereType) ?? ObjectFactory.AddComponent(newGO, mc1SphereType);
+          SetProp(c, "Radius", src.radius);
+          SetProp(c, "Center", src.position);
+          AddMarkerIfNeeded(newGO, existingMc1SphereGO, src);
+          EditorUtility.SetDirty(newGO);
+          convertedObject = newGO;
+          return "MagicaSphereCollider (MC1)";
+        }
+        case VRCPhysBoneColliderBase.ShapeType.Capsule:
+        {
+          var existingMc1CapsGO = FindExistingConvertedGO(effectiveRoot, src, mc1CapsuleType);
+          var newGO = existingMc1CapsGO ?? CreateChildGameObject(src.gameObject.name + "_MC1CapsuleCollider", effectiveRoot);
+          newGO.transform.localRotation = src.rotation;
+          var c = newGO.GetComponent(mc1CapsuleType) ?? ObjectFactory.AddComponent(newGO, mc1CapsuleType);
+
+          var axisEnumType = GetNestedTypeDeep(mc1CapsuleType, "Axis");
+          if (axisEnumType != null)
+            SetProp(c, "AxisMode", Enum.ToObject(axisEnumType, 1));
+
+          float mc1HalfLen = Mathf.Max(src.height / 2f - src.radius, 0f);
+          float clampedLength = Mathf.Clamp(mc1HalfLen, 0f, 1f);
+          if (mc1HalfLen > 1f)
+            warning =
+              "MC1 capsule half-length ("
+              + mc1HalfLen.ToString("F3")
+              + " m) exceeds MC1 max (1.0 m) and was clamped. Original VRC height: "
+              + src.height.ToString("F3")
+              + " m.";
+
+          SetProp(c, "Length", clampedLength);
+          SetProp(c, "StartRadius", src.radius);
+          SetProp(c, "EndRadius", src.radius);
+          SetProp(c, "Center", src.position);
+          AddMarkerIfNeeded(newGO, existingMc1CapsGO, src);
+          EditorUtility.SetDirty(newGO);
+          convertedObject = newGO;
+          return "MagicaCapsuleCollider (MC1)";
+        }
+        case VRCPhysBoneColliderBase.ShapeType.Plane:
+        {
+          var existingMc1PlaneGO = FindExistingConvertedGO(effectiveRoot, src, mc1PlaneType);
+          var newGO = existingMc1PlaneGO ?? CreateChildGameObject(src.gameObject.name + "_MC1PlaneCollider", effectiveRoot);
+          newGO.transform.localRotation = src.rotation;
+          var c = newGO.GetComponent(mc1PlaneType) ?? ObjectFactory.AddComponent(newGO, mc1PlaneType);
+          SetProp(c, "Center", src.position);
+          AddMarkerIfNeeded(newGO, existingMc1PlaneGO, src);
+          EditorUtility.SetDirty(newGO);
+          convertedObject = newGO;
+          return "MagicaPlaneCollider (MC1)";
+        }
+        default:
+          convertedObject = null;
+          return "MagicaCloth1 (unknown shape)";
+      }
+    }
+
+    private static string ConvertToMagicaCloth2(
+      VRCPhysBoneCollider src,
+      Type mc2SphereType,
+      Type mc2CapsuleType,
+      Type mc2PlaneType,
+      Transform effectiveRoot,
+      out GameObject convertedObject
+    )
+    {
+      switch (src.shapeType)
+      {
+        case VRCPhysBoneColliderBase.ShapeType.Sphere:
+        {
+          var existingMc2SphereGO = FindExistingConvertedGO(effectiveRoot, src, mc2SphereType);
+          var newGO = existingMc2SphereGO ?? CreateChildGameObject(src.gameObject.name + "_MC2SphereCollider", effectiveRoot);
+          var c = newGO.GetComponent(mc2SphereType) ?? ObjectFactory.AddComponent(newGO, mc2SphereType);
+          SetField(c, "center", src.position);
+
+          var setSizeFloat = mc2SphereType.GetMethod("SetSize", new[] { typeof(float) });
+          if (setSizeFloat != null)
+            setSizeFloat.Invoke(c, new object[] { src.radius });
+          else
+            SetField(c, "size", new Vector3(src.radius, 0f, 0f));
+
+          AddMarkerIfNeeded(newGO, existingMc2SphereGO, src);
+          EditorUtility.SetDirty(newGO);
+          convertedObject = newGO;
+          return "MagicaSphereCollider (MC2)";
+        }
+        case VRCPhysBoneColliderBase.ShapeType.Capsule:
+        {
+          var existingMc2CapsGO = FindExistingConvertedGO(effectiveRoot, src, mc2CapsuleType);
+          var newGO = existingMc2CapsGO ?? CreateChildGameObject(src.gameObject.name + "_MC2CapsuleCollider", effectiveRoot);
+          newGO.transform.localRotation = src.rotation;
+          var c = newGO.GetComponent(mc2CapsuleType) ?? ObjectFactory.AddComponent(newGO, mc2CapsuleType);
+          SetField(c, "center", src.position);
+
+          var dirEnumType = GetNestedTypeDeep(mc2CapsuleType, "Direction");
+          if (dirEnumType != null)
+            SetField(c, "direction", Enum.ToObject(dirEnumType, 1));
+
+          SetField(c, "radiusSeparation", false);
+          SetField(c, "alignedOnCenter", true);
+
+          var setSizeThree = mc2CapsuleType.GetMethod("SetSize", new[] { typeof(float), typeof(float), typeof(float) });
+          if (setSizeThree != null)
+            setSizeThree.Invoke(c, new object[] { src.radius, src.radius, src.height });
+          else
+            SetField(c, "size", new Vector3(src.radius, src.radius, src.height));
+
+          AddMarkerIfNeeded(newGO, existingMc2CapsGO, src);
+          EditorUtility.SetDirty(newGO);
+          convertedObject = newGO;
+          return "MagicaCapsuleCollider (MC2)";
+        }
+        case VRCPhysBoneColliderBase.ShapeType.Plane:
+        {
+          var existingMc2PlaneGO = FindExistingConvertedGO(effectiveRoot, src, mc2PlaneType);
+          var newGO = existingMc2PlaneGO ?? CreateChildGameObject(src.gameObject.name + "_MC2PlaneCollider", effectiveRoot);
+          newGO.transform.localRotation = src.rotation;
+          var c = newGO.GetComponent(mc2PlaneType) ?? ObjectFactory.AddComponent(newGO, mc2PlaneType);
+          SetField(c, "center", src.position);
+          AddMarkerIfNeeded(newGO, existingMc2PlaneGO, src);
+          EditorUtility.SetDirty(newGO);
+          convertedObject = newGO;
+          return "MagicaPlaneCollider (MC2)";
+        }
+        default:
+          convertedObject = null;
+          return "MagicaCloth2 (unknown shape)";
+      }
+    }
+
+    private static void AddMarkerIfNeeded(GameObject newGO, GameObject existingGO, VRCPhysBoneCollider source)
+    {
+      if (existingGO != null)
+        return;
+
+      var marker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
+      marker.sourceCollider = source;
+    }
+
+    private struct TargetTypes
+    {
+      public readonly Type dbType;
+      public readonly Type mc1SphereType;
+      public readonly Type mc1CapsuleType;
+      public readonly Type mc1PlaneType;
+      public readonly Type mc2SphereType;
+      public readonly Type mc2CapsuleType;
+      public readonly Type mc2PlaneType;
+
+      public TargetTypes(
+        Type dbType,
+        Type mc1SphereType,
+        Type mc1CapsuleType,
+        Type mc1PlaneType,
+        Type mc2SphereType,
+        Type mc2CapsuleType,
+        Type mc2PlaneType
+      )
+      {
+        this.dbType = dbType;
+        this.mc1SphereType = mc1SphereType;
+        this.mc1CapsuleType = mc1CapsuleType;
+        this.mc1PlaneType = mc1PlaneType;
+        this.mc2SphereType = mc2SphereType;
+        this.mc2CapsuleType = mc2CapsuleType;
+        this.mc2PlaneType = mc2PlaneType;
+      }
+    }
+  }
+}

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Conversion/VRCPhysBoneColliderConversionTypes.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Conversion/VRCPhysBoneColliderConversionTypes.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace uk.novavoidhowl.dev.cvrfury.compiled.vrccolliders
+{
+  public enum ConversionMessageSeverity
+  {
+    Info,
+    Warning,
+    Error
+  }
+
+  public sealed class ConversionMessage
+  {
+    public ConversionMessageSeverity Severity;
+    public string Code;
+    public string Text;
+
+    public ConversionMessage(ConversionMessageSeverity severity, string code, string text)
+    {
+      Severity = severity;
+      Code = code;
+      Text = text;
+    }
+  }
+
+  [System.Flags]
+  public enum PhysBoneColliderTarget
+  {
+    None = 0,
+    DynamicBone = 1,
+    MagicaCloth1 = 2,
+    MagicaCloth2 = 4
+  }
+
+  public sealed class VRCPhysBoneColliderConversionOptions
+  {
+    public bool RegisterUndo = true;
+
+    public static VRCPhysBoneColliderConversionOptions ForInspector()
+    {
+      return new VRCPhysBoneColliderConversionOptions();
+    }
+
+    public static VRCPhysBoneColliderConversionOptions ForBatch()
+    {
+      return new VRCPhysBoneColliderConversionOptions();
+    }
+  }
+
+  public sealed class VRCPhysBoneColliderConversionAvailability
+  {
+    public bool CanConvertDynamicBone;
+    public bool CanConvertMagicaCloth1;
+    public bool CanConvertMagicaCloth2;
+    public readonly List<ConversionMessage> Messages = new List<ConversionMessage>();
+  }
+
+  public sealed class VRCPhysBoneColliderConversionGuidance
+  {
+    public readonly List<ConversionMessage> Messages = new List<ConversionMessage>();
+  }
+
+  public sealed class VRCPhysBoneColliderConversionResult
+  {
+    public bool Success;
+    public string SummaryTitle;
+    public string SummaryMessage;
+    public Transform EffectiveRoot;
+    public readonly List<string> ConvertedTargets = new List<string>();
+    public readonly List<GameObject> CreatedOrUpdatedObjects = new List<GameObject>();
+    public readonly List<ConversionMessage> Messages = new List<ConversionMessage>();
+
+    public static VRCPhysBoneColliderConversionResult Failed(string title, string message, string code)
+    {
+      var result = new VRCPhysBoneColliderConversionResult
+      {
+        Success = false,
+        SummaryTitle = title,
+        SummaryMessage = message
+      };
+      result.Messages.Add(new ConversionMessage(ConversionMessageSeverity.Error, code, message));
+      return result;
+    }
+  }
+}

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/Editors/VRCPhysBoneColliderEditor.cs
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/Editors/VRCPhysBoneColliderEditor.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using UnityEngine;
 using UnityEngine.UIElements;
 using UnityEditor;
 using VRC.Dynamics;
 using VRC.SDK3.Dynamics.PhysBone.Components;
 using VRC.SDK3.Dynamics.PhysBone.Editors.Common;
+using uk.novavoidhowl.dev.cvrfury.compiled.vrccolliders;
 using uk.novavoidhowl.dev.cvrfury.VRCstub.Common; // Shared UI styles
 
 namespace VRC.SDK3.Dynamics.PhysBone.Editors
@@ -45,89 +45,6 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
           return t;
       }
       return null;
-    }
-
-    // -------------------------------------------------------------------------
-    // Axis helper — returns 0=X, 1=Y, 2=Z for the dominant axis of a quaternion
-    // -------------------------------------------------------------------------
-
-    private static int GetDominantAxis(Quaternion rotation)
-    {
-      Vector3 fwd = rotation * Vector3.forward;
-      float ax = Mathf.Abs(fwd.x);
-      float ay = Mathf.Abs(fwd.y);
-      float az = Mathf.Abs(fwd.z);
-      if (ax >= ay && ax >= az)
-        return 0; // X
-      if (ay >= ax && ay >= az)
-        return 1; // Y
-      return 2; // Z
-    }
-
-    // -------------------------------------------------------------------------
-    // Reflection helpers — walk the inheritance chain so base-class
-    // properties/fields are found when called on a derived type instance.
-    // -------------------------------------------------------------------------
-
-    private static void SetProp(object obj, string name, object value)
-    {
-      var type = obj.GetType();
-      while (type != null)
-      {
-        var prop = type.GetProperty(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-        if (prop != null && prop.CanWrite)
-        {
-          prop.SetValue(obj, value);
-          return;
-        }
-        type = type.BaseType;
-      }
-      Debug.LogWarning($"[CVRFury] Property '{name}' not found on {obj.GetType().FullName}");
-    }
-
-    private static void SetField(object obj, string name, object value)
-    {
-      var type = obj.GetType();
-      while (type != null)
-      {
-        var field = type.GetField(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-        if (field != null)
-        {
-          field.SetValue(obj, value);
-          return;
-        }
-        type = type.BaseType;
-      }
-      Debug.LogWarning($"[CVRFury] Field '{name}' not found on {obj.GetType().FullName}");
-    }
-
-    private static Type GetNestedTypeDeep(Type type, string nestedName)
-    {
-      while (type != null)
-      {
-        var nested = type.GetNestedType(nestedName, BindingFlags.Public);
-        if (nested != null)
-          return nested;
-        type = type.BaseType;
-      }
-      return null;
-    }
-
-    // -------------------------------------------------------------------------
-    // Create a named child GameObject under a parent, registered with Undo.
-    // The new GO is positioned at local identity so that the component's own
-    // center/offset field carries the position data from the VRC collider.
-    // -------------------------------------------------------------------------
-
-    private static GameObject CreateChildGameObject(string name, Transform parent)
-    {
-      var go = new GameObject(name);
-      Undo.RegisterCreatedObjectUndo(go, "Create converted collider");
-      go.transform.SetParent(parent, false);
-      go.transform.localPosition = Vector3.zero;
-      go.transform.localRotation = Quaternion.identity;
-      go.transform.localScale = Vector3.one;
-      return go;
     }
 
     // -------------------------------------------------------------------------
@@ -254,6 +171,21 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       container.Add(box);
     }
 
+    private static void ShowConversionResultDialog(VRCPhysBoneColliderConversionResult result)
+    {
+      var msg = result.SummaryMessage;
+      if (result.Messages.Count > 0)
+      {
+        msg += "\n\nMessages:";
+        foreach (var message in result.Messages)
+        {
+          msg += "\n- " + message.Text;
+        }
+      }
+
+      EditorUtility.DisplayDialog(result.SummaryTitle, msg, "OK");
+    }
+
     // -------------------------------------------------------------------------
     // Inspector GUI
     // -------------------------------------------------------------------------
@@ -290,7 +222,9 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       stubVersionLabel.AddToClassList(STUB_VERSION);
       root.Add(stubVersionLabel);
 
-      var uiVersionLabel = new Label($"UI Version: {UIVersion.CurrentVersion}");
+      var uiVersionLabel = new Label(
+        $"UI Version: {UIVersion.CurrentVersion} | API Version: {VRCPhysBoneColliderConversionActions.ApiVersion}"
+      );
       uiVersionLabel.AddToClassList(UI_VERSION);
       root.Add(uiVersionLabel);
 
@@ -437,73 +371,25 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
 
       convertButton.clicked += () =>
       {
-        var converted = new List<string>();
-        var warnings = new List<string>();
-
-        bool doDb = dbToggle.enabledSelf && dbToggle.value;
-        bool doMc1 = mc1Toggle.enabledSelf && mc1Toggle.value;
-        bool doMc2 = mc2Toggle.enabledSelf && mc2Toggle.value;
-
-        // Cross-cutting warnings
-        if (src.insideBounds && (doMc1 || doMc2))
-          warnings.Add("Inside-bounds is not supported by MagicaCloth \u2014 Outside mode applied.");
-
-        if (isPlane && (doMc1 || doMc2))
-          warnings.Add(
-            "Plane: VRC rotation has been applied to the new child GO's local rotation. Verify the orientation in the Scene view."
-          );
+        var targets = PhysBoneColliderTarget.None;
+        if (dbToggle.enabledSelf && dbToggle.value)
+          targets |= PhysBoneColliderTarget.DynamicBone;
+        if (mc1Toggle.enabledSelf && mc1Toggle.value)
+          targets |= PhysBoneColliderTarget.MagicaCloth1;
+        if (mc2Toggle.enabledSelf && mc2Toggle.value)
+          targets |= PhysBoneColliderTarget.MagicaCloth2;
 
         // Group all child-GO creation + component additions into one undoable step
         Undo.IncrementCurrentGroup();
         Undo.SetCurrentGroupName("Convert PhysBone Collider");
 
-        if (doDb)
-        {
-          ConvertToDynamicBone(src, capturedDbType, capturedEffectiveRoot);
-          converted.Add("DynamicBoneCollider");
-        }
+        var result = VRCPhysBoneColliderConversionActions.Convert(
+          src,
+          targets,
+          VRCPhysBoneColliderConversionOptions.ForInspector()
+        );
 
-        if (doMc1)
-        {
-          string mc1Warning;
-          string mc1Name = ConvertToMagicaCloth1(
-            src,
-            capturedMc1SphereType,
-            capturedMc1CapsuleType,
-            capturedMc1PlaneType,
-            capturedEffectiveRoot,
-            out mc1Warning
-          );
-          converted.Add(mc1Name);
-          if (mc1Warning != null)
-            warnings.Add(mc1Warning);
-        }
-
-        if (doMc2)
-        {
-          string mc2Name = ConvertToMagicaCloth2(
-            src,
-            capturedMc2SphereType,
-            capturedMc2CapsuleType,
-            capturedMc2PlaneType,
-            capturedEffectiveRoot
-          );
-          converted.Add(mc2Name);
-        }
-
-        // Summary dialog
-        string msg =
-          "Created child GameObjects under \""
-          + capturedEffectiveRoot.name
-          + "\":\n"
-          + string.Join(", ", converted.ToArray());
-        if (warnings.Count > 0)
-        {
-          msg += "\n\nWarnings:";
-          foreach (var w in warnings)
-            msg += "\n\u2022 " + w;
-        }
-        EditorUtility.DisplayDialog("PhysBone Collider Converted", msg, "OK");
+        ShowConversionResultDialog(result);
 
         // Refresh the existing-conversions panel immediately so the new links
         // appear without the user needing to deselect and reselect the object.
@@ -517,7 +403,8 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
         );
 
         // Update button label now that at least one conversion exists
-        convertButton.text = "Re-Convert";
+        if (result.Success)
+          convertButton.text = "Re-Convert";
       };
 
       root.Add(convertButton);
@@ -554,264 +441,6 @@ namespace VRC.SDK3.Dynamics.PhysBone.Editors
       return root;
     }
 
-    // -------------------------------------------------------------------------
-    // Conversion: DynamicBone
-    // Creates a new child GO under effectiveRoot, then uses SerializedObject to
-    // set the (public) fields robustly through Unity's serialization layer.
-    // -------------------------------------------------------------------------
-
-    private static void ConvertToDynamicBone(VRCPhysBoneCollider src, Type dbType, Transform effectiveRoot)
-    {
-      if (src.shapeType == VRCPhysBoneColliderBase.ShapeType.Plane)
-      {
-        Debug.LogError("[CVRFury] ConvertToDynamicBone called with Plane shape \u2014 aborting.");
-        return;
-      }
-
-      var existingDbGO = FindExistingConvertedGO(effectiveRoot, src, dbType);
-      var newGO = existingDbGO ?? CreateChildGameObject(src.gameObject.name + "_DBCollider", effectiveRoot);
-
-      // VRC capsule extends along its Y-axis; apply the VRC rotation to the child GO
-      // so that direction Y on the DynamicBoneCollider aligns with the intended capsule axis.
-      // (For spheres the rotation has no meaningful effect but applying it is harmless.)
-      if (src.shapeType == VRCPhysBoneColliderBase.ShapeType.Capsule)
-        newGO.transform.localRotation = src.rotation;
-
-      var dbc = newGO.GetComponent(dbType) ?? ObjectFactory.AddComponent(newGO, dbType);
-      var so = new SerializedObject(dbc);
-
-      var radProp = so.FindProperty("m_Radius");
-      var hProp = so.FindProperty("m_Height");
-      var cProp = so.FindProperty("m_Center");
-      var dirProp = so.FindProperty("m_Direction");
-      var bndProp = so.FindProperty("m_Bound");
-
-      if (radProp != null)
-        radProp.floatValue = src.radius;
-      if (hProp != null)
-        hProp.floatValue = src.shapeType == VRCPhysBoneColliderBase.ShapeType.Capsule ? src.height : 0f;
-      if (cProp != null)
-        cProp.vector3Value = src.position;
-      // Always use Y-axis (1) — VRC's natural capsule axis is Y; orientation is carried by localRotation.
-      if (dirProp != null)
-        dirProp.enumValueIndex = 1;
-      if (bndProp != null)
-        bndProp.enumValueIndex = src.insideBounds ? 1 : 0; // 0=Outside 1=Inside
-
-      so.ApplyModifiedProperties();
-      if (existingDbGO == null)
-      {
-        var dbMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-        dbMarker.sourceCollider = src;
-      }
-      EditorUtility.SetDirty(newGO);
-    }
-
-    // -------------------------------------------------------------------------
-    // Conversion: MagicaCloth 1
-    // Creates a new child GO under effectiveRoot per shape type.
-    // MC1 fields are [SerializeField] private; access via their public properties.
-    // Returns the display name of the added component, and an optional warning.
-    // -------------------------------------------------------------------------
-
-    private static string ConvertToMagicaCloth1(
-      VRCPhysBoneCollider src,
-      Type mc1SphereType,
-      Type mc1CapsuleType,
-      Type mc1PlaneType,
-      Transform effectiveRoot,
-      out string warning
-    )
-    {
-      warning = null;
-      string addedName;
-
-      switch (src.shapeType)
-      {
-        case VRCPhysBoneColliderBase.ShapeType.Sphere:
-        {
-          var existingMc1SphereGO = FindExistingConvertedGO(effectiveRoot, src, mc1SphereType);
-          var newGO =
-            existingMc1SphereGO ?? CreateChildGameObject(src.gameObject.name + "_MC1SphereCollider", effectiveRoot);
-          var c = newGO.GetComponent(mc1SphereType) ?? ObjectFactory.AddComponent(newGO, mc1SphereType);
-          SetProp(c, "Radius", src.radius);
-          SetProp(c, "Center", src.position);
-          if (existingMc1SphereGO == null)
-          {
-            var mc1SphereMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-            mc1SphereMarker.sourceCollider = src;
-          }
-          EditorUtility.SetDirty(newGO);
-          addedName = "MagicaSphereCollider (MC1)";
-          break;
-        }
-        case VRCPhysBoneColliderBase.ShapeType.Capsule:
-        {
-          var existingMc1CapsGO = FindExistingConvertedGO(effectiveRoot, src, mc1CapsuleType);
-          var newGO =
-            existingMc1CapsGO ?? CreateChildGameObject(src.gameObject.name + "_MC1CapsuleCollider", effectiveRoot);
-          // VRC capsule extends along its Y-axis; apply VRC rotation to the child GO
-          // so the GO's local Y aligns with the intended capsule axis.
-          newGO.transform.localRotation = src.rotation;
-          var c = newGO.GetComponent(mc1CapsuleType) ?? ObjectFactory.AddComponent(newGO, mc1CapsuleType);
-
-          // AxisMode: always Y (1) — VRC's natural capsule axis is Y; orientation carried by GO's rotation.
-          var axisEnumType = GetNestedTypeDeep(mc1CapsuleType, "Axis");
-          if (axisEnumType != null)
-            SetProp(c, "AxisMode", Enum.ToObject(axisEnumType, 1));
-
-          // MC1 Length is a HALF-length (distance from center to one end sphere).
-          // Total visual span = 2*Length + 2*radius. MC2/VRC height = total tip-to-tip,
-          // so: Length = src.height/2 - src.radius (clamped to MC1's [Range(0,1)] max).
-          float mc1HalfLen = Mathf.Max(src.height / 2f - src.radius, 0f);
-          float clampedLength = Mathf.Clamp(mc1HalfLen, 0f, 1f);
-          if (mc1HalfLen > 1f)
-            warning =
-              $"MC1 capsule half-length ({mc1HalfLen:F3}\u202fm) exceeds MC1 max (1.0\u202fm) and was clamped. Original VRC height: {src.height:F3}\u202fm.";
-
-          SetProp(c, "Length", clampedLength);
-          SetProp(c, "StartRadius", src.radius);
-          SetProp(c, "EndRadius", src.radius);
-          SetProp(c, "Center", src.position);
-          if (existingMc1CapsGO == null)
-          {
-            var mc1CapsMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-            mc1CapsMarker.sourceCollider = src;
-          }
-          EditorUtility.SetDirty(newGO);
-          addedName = "MagicaCapsuleCollider (MC1)";
-          break;
-        }
-        case VRCPhysBoneColliderBase.ShapeType.Plane:
-        {
-          var existingMc1PlaneGO = FindExistingConvertedGO(effectiveRoot, src, mc1PlaneType);
-          var newGO =
-            existingMc1PlaneGO ?? CreateChildGameObject(src.gameObject.name + "_MC1PlaneCollider", effectiveRoot);
-          // MC1 uses the GO's Y+ axis as the plane normal — apply the VRC rotation so
-          // the Y+ of this child GO matches the intended plane normal direction.
-          newGO.transform.localRotation = src.rotation;
-          var c = newGO.GetComponent(mc1PlaneType) ?? ObjectFactory.AddComponent(newGO, mc1PlaneType);
-          SetProp(c, "Center", src.position);
-          if (existingMc1PlaneGO == null)
-          {
-            var mc1PlaneMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-            mc1PlaneMarker.sourceCollider = src;
-          }
-          EditorUtility.SetDirty(newGO);
-          addedName = "MagicaPlaneCollider (MC1)";
-          break;
-        }
-        default:
-          return "MagicaCloth1 (unknown shape)";
-      }
-
-      return addedName;
-    }
-
-    // -------------------------------------------------------------------------
-    // Conversion: MagicaCloth 2
-    // Creates a new child GO under effectiveRoot per shape type.
-    // MC2 exposes public fields (center, direction, radiusSeparation,
-    // alignedOnCenter) and public SetSize() methods on each collider type.
-    // Returns the display name of the added component.
-    // -------------------------------------------------------------------------
-
-    private static string ConvertToMagicaCloth2(
-      VRCPhysBoneCollider src,
-      Type mc2SphereType,
-      Type mc2CapsuleType,
-      Type mc2PlaneType,
-      Transform effectiveRoot
-    )
-    {
-      string addedName;
-
-      switch (src.shapeType)
-      {
-        case VRCPhysBoneColliderBase.ShapeType.Sphere:
-        {
-          var existingMc2SphereGO = FindExistingConvertedGO(effectiveRoot, src, mc2SphereType);
-          var newGO =
-            existingMc2SphereGO ?? CreateChildGameObject(src.gameObject.name + "_MC2SphereCollider", effectiveRoot);
-          var c = newGO.GetComponent(mc2SphereType) ?? ObjectFactory.AddComponent(newGO, mc2SphereType);
-          SetField(c, "center", src.position);
-
-          // MagicaSphereCollider.SetSize(float radius) sets size = new Vector3(r,0,0)
-          var setSizeFloat = mc2SphereType.GetMethod("SetSize", new[] { typeof(float) });
-          if (setSizeFloat != null)
-            setSizeFloat.Invoke(c, new object[] { src.radius });
-          else
-            SetField(c, "size", new Vector3(src.radius, 0f, 0f)); // fallback
-
-          if (existingMc2SphereGO == null)
-          {
-            var mc2SphereMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-            mc2SphereMarker.sourceCollider = src;
-          }
-          EditorUtility.SetDirty(newGO);
-          addedName = "MagicaSphereCollider (MC2)";
-          break;
-        }
-        case VRCPhysBoneColliderBase.ShapeType.Capsule:
-        {
-          var existingMc2CapsGO = FindExistingConvertedGO(effectiveRoot, src, mc2CapsuleType);
-          var newGO =
-            existingMc2CapsGO ?? CreateChildGameObject(src.gameObject.name + "_MC2CapsuleCollider", effectiveRoot);
-          // VRC capsule extends along its Y-axis; apply VRC rotation to the child GO
-          // so the GO's local Y aligns with the intended capsule axis.
-          newGO.transform.localRotation = src.rotation;
-          var c = newGO.GetComponent(mc2CapsuleType) ?? ObjectFactory.AddComponent(newGO, mc2CapsuleType);
-          SetField(c, "center", src.position);
-
-          // Direction: always Y (1) — VRC's natural capsule axis is Y; orientation carried by GO's rotation.
-          var dirEnumType = GetNestedTypeDeep(mc2CapsuleType, "Direction");
-          if (dirEnumType != null)
-            SetField(c, "direction", Enum.ToObject(dirEnumType, 1)); // 1 = Y-Axis
-
-          SetField(c, "radiusSeparation", false); // uniform radius
-          SetField(c, "alignedOnCenter", true);
-
-          // MagicaCapsuleCollider.SetSize(float startR, float endR, float length)
-          var setSizeThree = mc2CapsuleType.GetMethod("SetSize", new[] { typeof(float), typeof(float), typeof(float) });
-          if (setSizeThree != null)
-            setSizeThree.Invoke(c, new object[] { src.radius, src.radius, src.height });
-          else
-            SetField(c, "size", new Vector3(src.radius, src.radius, src.height)); // fallback
-
-          if (existingMc2CapsGO == null)
-          {
-            var mc2CapsMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-            mc2CapsMarker.sourceCollider = src;
-          }
-          EditorUtility.SetDirty(newGO);
-          addedName = "MagicaCapsuleCollider (MC2)";
-          break;
-        }
-        case VRCPhysBoneColliderBase.ShapeType.Plane:
-        {
-          var existingMc2PlaneGO = FindExistingConvertedGO(effectiveRoot, src, mc2PlaneType);
-          var newGO =
-            existingMc2PlaneGO ?? CreateChildGameObject(src.gameObject.name + "_MC2PlaneCollider", effectiveRoot);
-          // MC2 uses the GO's Y+ axis as the plane normal — apply the VRC rotation so
-          // the Y+ of this child GO matches the intended plane normal direction.
-          newGO.transform.localRotation = src.rotation;
-          var c = newGO.GetComponent(mc2PlaneType) ?? ObjectFactory.AddComponent(newGO, mc2PlaneType);
-          SetField(c, "center", src.position);
-          if (existingMc2PlaneGO == null)
-          {
-            var mc2PlaneMarker = newGO.AddComponent<CVRFuryConvertedColliderMarker>();
-            mc2PlaneMarker.sourceCollider = src;
-          }
-          EditorUtility.SetDirty(newGO);
-          addedName = "MagicaPlaneCollider (MC2)";
-          break;
-        }
-        default:
-          return "MagicaCloth2 (unknown shape)";
-      }
-
-      return addedName;
-    }
   }
 
   // -------------------------------------------------------------------------

--- a/VRCStubConvertAndUI/VRCPBUIAndConverter/VRCPBUIAndConverter.csproj
+++ b/VRCStubConvertAndUI/VRCPBUIAndConverter/VRCPBUIAndConverter.csproj
@@ -56,11 +56,16 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\APIVersion.cs" />
     <Compile Include="Common\UIVersion.cs" />
+    <Compile Include="Conversion\VRCPhysBoneColliderConversionActions.cs" />
+    <Compile Include="Conversion\VRCPhysBoneColliderConversionTypes.cs" />
     <Compile Include="Editors\VRCPhysBoneEditor.cs" />
     <Compile Include="Editors\VRCPhysBoneColliderEditor.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="Common\" />
+    <Folder Include="Conversion\" />
     <Folder Include="Editors\" />
     <Folder Include="Resources\" />
   </ItemGroup>

--- a/VRCStubConvertAndUI/VRCPCUIAndConverter/Common/APIVersion.cs
+++ b/VRCStubConvertAndUI/VRCPCUIAndConverter/Common/APIVersion.cs
@@ -1,16 +1,22 @@
 using System;
 
-namespace VRC.SDK3.Dynamics.Contact.Editors.Common
+namespace uk.novavoidhowl.dev.cvrfury.compiled.vrccontacts
 {
-  public static class UIVersion
+  public static class APIVersion
   {
-    private static readonly Version _version = new Version(2, 3, 0);
+    private static readonly Version _version = new Version(1, 0, 0);
 
     // For serialization and display
-    public static string CurrentVersion => _version.ToString();
+    public static string CurrentVersion
+    {
+      get { return _version.ToString(); }
+    }
 
     // For version comparison
-    public static Version AsVersion => _version;
+    public static Version AsVersion
+    {
+      get { return _version; }
+    }
 
     // Helper method for version checking
     public static bool IsVersionAtLeast(Version otherVersion)

--- a/VRCStubConvertAndUI/VRCPCUIAndConverter/Common/UIVersion.cs
+++ b/VRCStubConvertAndUI/VRCPCUIAndConverter/Common/UIVersion.cs
@@ -4,7 +4,7 @@ namespace VRC.SDK3.Dynamics.Contact.Editors.Common
 {
   public static class UIVersion
   {
-    private static readonly Version _version = new Version(2, 1, 0);
+    private static readonly Version _version = new Version(2, 2, 0);
 
     // For serialization and display
     public static string CurrentVersion => _version.ToString();

--- a/VRCStubConvertAndUI/VRCPCUIAndConverter/Conversion/VRCContactConversionActions.cs
+++ b/VRCStubConvertAndUI/VRCPCUIAndConverter/Conversion/VRCContactConversionActions.cs
@@ -1,0 +1,515 @@
+using System;
+using System.Collections;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using VRC.SDK3.Dynamics.Contact.Components;
+
+namespace uk.novavoidhowl.dev.cvrfury.compiled.vrccontacts
+{
+  public static class VRCContactConversionActions
+  {
+    private const string UPDATE_METHOD_OVERRIDE = "Override";
+
+    public static string ApiVersion
+    {
+      get { return APIVersion.CurrentVersion; }
+    }
+
+    public static Version ApiVersionAsVersion
+    {
+      get { return APIVersion.AsVersion; }
+    }
+
+    public static bool IsApiVersionAtLeast(Version otherVersion)
+    {
+      return APIVersion.IsVersionAtLeast(otherVersion);
+    }
+
+    public static bool IsApiVersionAtLeast(string otherVersion)
+    {
+      return APIVersion.IsVersionAtLeast(otherVersion);
+    }
+
+    public static VRCContactConversionAvailability GetSenderAvailability()
+    {
+      var availability = new VRCContactConversionAvailability();
+      availability.IsAvailable = FindRequiredCVRPointerType() != null;
+      if (!availability.IsAvailable)
+      {
+        availability.Messages.Add(
+          new ConversionMessage(
+            ConversionMessageSeverity.Error,
+            "missing_cvr_pointer",
+            "Could not find CVRPointer component type. Make sure CVR CCK is imported."
+          )
+        );
+      }
+      return availability;
+    }
+
+    public static VRCContactConversionAvailability GetReceiverAvailability()
+    {
+      var availability = new VRCContactConversionAvailability();
+      var types = FindRequiredReceiverCVRTypes();
+      availability.IsAvailable =
+        types.triggerType != null && types.taskType != null && types.taskStayType != null;
+      if (!availability.IsAvailable)
+      {
+        availability.Messages.Add(
+          new ConversionMessage(
+            ConversionMessageSeverity.Error,
+            "missing_cvr_trigger_types",
+            "Could not find required CVR component types. Make sure CVR CCK is imported."
+          )
+        );
+      }
+      return availability;
+    }
+
+    public static VRCContactConversionGuidance GetSenderGuidance()
+    {
+      var guidance = new VRCContactConversionGuidance();
+      guidance.Messages.Add(
+        new ConversionMessage(
+          ConversionMessageSeverity.Info,
+          "sender_destructive_conversion",
+          "Contact Sender conversion creates one CVR Pointer per collision tag and removes the source VRC component after success."
+        )
+      );
+      return guidance;
+    }
+
+    public static VRCContactConversionGuidance GetReceiverGuidance()
+    {
+      var guidance = new VRCContactConversionGuidance();
+      guidance.Messages.Add(
+        new ConversionMessage(
+          ConversionMessageSeverity.Info,
+          "receiver_destructive_conversion",
+          "Contact Receiver conversion creates one CVR Advanced Avatar Settings Trigger and removes the source VRC component after success."
+        )
+      );
+      return guidance;
+    }
+
+    public static VRCContactConversionResult ConvertSender(
+      VRCContactSender source,
+      VRCContactConversionOptions options
+    )
+    {
+      if (source == null)
+        return VRCContactConversionResult.Failed("Contact Sender Conversion Failed", "Source sender is missing.", "missing_source");
+
+      if (options == null)
+        options = VRCContactConversionOptions.ForInspector();
+
+      var senderGameObject = source.gameObject;
+      var cvrPointerType = FindRequiredCVRPointerType();
+      if (cvrPointerType == null)
+      {
+        const string msg = "Could not find CVRPointer component type. Make sure CVR CCK is imported.";
+        Debug.LogError(msg);
+        return VRCContactConversionResult.Failed("Contact Sender Conversion Failed", msg, "missing_cvr_pointer");
+      }
+
+      var result = new VRCContactConversionResult
+      {
+        Success = true,
+        SummaryTitle = "Contact Sender Conversion Complete",
+        SummaryMessage =
+          "The VRC Contact Sender has been successfully converted to CVR Pointer(s). "
+          + "The original component has been removed and new child GameObject(s) with CVR pointers have been created "
+          + "(one for each collision tag). "
+          + "The pointers are placed under the rootTransform if set, otherwise under the original component's GameObject."
+      };
+
+      var parentTransform = source.rootTransform != null ? source.rootTransform : senderGameObject.transform;
+
+      for (int i = 0; i < source.collisionTags.Count; i++)
+      {
+        var collisionTag = source.collisionTags[i];
+        var pointerGameObject = CreateChildGameObject(
+          "CVR_Pointer" + (i + 1) + "_From_" + senderGameObject.name,
+          parentTransform,
+          options
+        );
+
+        AddColliderBasedOnShape(source, pointerGameObject, options, result);
+
+        var cvrPointer = AddComponent(pointerGameObject, cvrPointerType, options);
+        SetFieldOrProperty(cvrPointerType, cvrPointer, "type", collisionTag);
+        result.CreatedObjects.Add(pointerGameObject);
+      }
+
+      EditorUtility.SetDirty(senderGameObject);
+      if (source.rootTransform != null)
+        EditorUtility.SetDirty(source.rootTransform.gameObject);
+
+      if (options.RemoveSourceComponent)
+      {
+        DestroyComponent(source, options);
+        result.SourceRemoved = true;
+      }
+
+      return result;
+    }
+
+    public static VRCContactConversionResult ConvertReceiver(
+      VRCContactReceiver source,
+      VRCContactConversionOptions options
+    )
+    {
+      if (source == null)
+        return VRCContactConversionResult.Failed("Contact Receiver Conversion Failed", "Source receiver is missing.", "missing_source");
+
+      if (options == null)
+        options = VRCContactConversionOptions.ForInspector();
+
+      var receiverGameObject = source.gameObject;
+      var types = FindRequiredReceiverCVRTypes();
+
+      if (types.triggerType == null || types.taskType == null || types.taskStayType == null)
+      {
+        const string msg = "Could not find required CVR component types. Make sure CVR CCK is imported.";
+        Debug.LogError(msg);
+        return VRCContactConversionResult.Failed("Contact Receiver Conversion Failed", msg, "missing_cvr_trigger_types");
+      }
+
+      var result = new VRCContactConversionResult
+      {
+        Success = true,
+        SummaryTitle = "Contact Receiver Conversion Complete",
+        SummaryMessage =
+          "The VRC Contact Receiver has been successfully converted to a CVR Advanced Avatar Settings Trigger. "
+          + "The original component has been removed and a new child GameObject with the CVR trigger has been created. "
+          + "The trigger is placed under the rootTransform if set, otherwise under the original component's GameObject."
+      };
+
+      var parentTransform = source.rootTransform != null ? source.rootTransform : receiverGameObject.transform;
+      var triggerGameObject = CreateChildGameObject("CVR_Trigger_From_" + receiverGameObject.name, parentTransform, options);
+
+      AddColliderBasedOnShape(source, triggerGameObject, options, result);
+
+      var cvrTrigger = AddComponent(triggerGameObject, types.triggerType, options);
+      ConfigureTriggerProperties(source, cvrTrigger, types.triggerType);
+      ConfigureTriggerTasks(source, cvrTrigger, types.triggerType, types.taskType, types.taskStayType);
+
+      result.CreatedObjects.Add(triggerGameObject);
+
+      EditorUtility.SetDirty(triggerGameObject);
+      EditorUtility.SetDirty(receiverGameObject);
+      if (source.rootTransform != null)
+        EditorUtility.SetDirty(source.rootTransform.gameObject);
+
+      if (options.RemoveSourceComponent)
+      {
+        DestroyComponent(source, options);
+        result.SourceRemoved = true;
+      }
+
+      return result;
+    }
+
+    private static Type FindRequiredCVRPointerType()
+    {
+      return AppDomain.CurrentDomain
+        .GetAssemblies()
+        .SelectMany(a => a.GetTypes())
+        .FirstOrDefault(t => t.Name == "CVRPointer");
+    }
+
+    private static ReceiverCVRTypes FindRequiredReceiverCVRTypes()
+    {
+      var triggerType = AppDomain.CurrentDomain
+        .GetAssemblies()
+        .SelectMany(a => a.GetTypes())
+        .FirstOrDefault(t => t.Name == "CVRAdvancedAvatarSettingsTrigger");
+
+      var taskType = AppDomain.CurrentDomain
+        .GetAssemblies()
+        .SelectMany(a => a.GetTypes())
+        .FirstOrDefault(t => t.Name == "CVRAdvancedAvatarSettingsTriggerTask");
+
+      var taskStayType = AppDomain.CurrentDomain
+        .GetAssemblies()
+        .SelectMany(a => a.GetTypes())
+        .FirstOrDefault(t => t.Name == "CVRAdvancedAvatarSettingsTriggerTaskStay");
+
+      return new ReceiverCVRTypes(triggerType, taskType, taskStayType);
+    }
+
+    private static GameObject CreateChildGameObject(
+      string name,
+      Transform parentTransform,
+      VRCContactConversionOptions options
+    )
+    {
+      var gameObject = new GameObject(name);
+      if (options.RegisterUndo)
+        Undo.RegisterCreatedObjectUndo(gameObject, "Convert VRC Contact Component");
+
+      gameObject.transform.SetParent(parentTransform, false);
+      return gameObject;
+    }
+
+    private static Component AddComponent(GameObject gameObject, Type componentType, VRCContactConversionOptions options)
+    {
+      if (options.RegisterUndo)
+        return Undo.AddComponent(gameObject, componentType);
+
+      return gameObject.AddComponent(componentType);
+    }
+
+    private static T AddComponent<T>(GameObject gameObject, VRCContactConversionOptions options)
+      where T : Component
+    {
+      if (options.RegisterUndo)
+        return Undo.AddComponent<T>(gameObject);
+
+      return gameObject.AddComponent<T>();
+    }
+
+    private static void DestroyComponent(Component component, VRCContactConversionOptions options)
+    {
+      if (options.RegisterUndo)
+        Undo.DestroyObjectImmediate(component);
+      else
+        UnityEngine.Object.DestroyImmediate(component);
+    }
+
+    private static void AddColliderBasedOnShape(
+      VRCContactSender source,
+      GameObject pointerGameObject,
+      VRCContactConversionOptions options,
+      VRCContactConversionResult result
+    )
+    {
+      switch (source.shapeType)
+      {
+        case VRC.Dynamics.ContactBase.ShapeType.Sphere:
+          var sphereCollider = AddComponent<SphereCollider>(pointerGameObject, options);
+          sphereCollider.radius = source.radius;
+          sphereCollider.isTrigger = true;
+          pointerGameObject.transform.localPosition = source.position;
+          break;
+
+        case VRC.Dynamics.ContactBase.ShapeType.Capsule:
+          var capsuleCollider = AddComponent<CapsuleCollider>(pointerGameObject, options);
+          capsuleCollider.radius = source.radius;
+          capsuleCollider.height = source.height;
+          capsuleCollider.direction = 1;
+          capsuleCollider.isTrigger = true;
+          pointerGameObject.transform.localPosition = source.position;
+          pointerGameObject.transform.localRotation = source.rotation;
+          break;
+
+        default:
+          AddUnknownShapeWarning(result, source.shapeType.ToString());
+          break;
+      }
+    }
+
+    private static void AddColliderBasedOnShape(
+      VRCContactReceiver source,
+      GameObject triggerGameObject,
+      VRCContactConversionOptions options,
+      VRCContactConversionResult result
+    )
+    {
+      switch (source.shapeType)
+      {
+        case VRC.Dynamics.ContactBase.ShapeType.Sphere:
+          var sphereCollider = AddComponent<SphereCollider>(triggerGameObject, options);
+          sphereCollider.radius = source.radius;
+          sphereCollider.isTrigger = true;
+          triggerGameObject.transform.localPosition = source.position;
+          break;
+
+        case VRC.Dynamics.ContactBase.ShapeType.Capsule:
+          var capsuleCollider = AddComponent<CapsuleCollider>(triggerGameObject, options);
+          capsuleCollider.radius = source.radius;
+          capsuleCollider.height = source.height;
+          capsuleCollider.direction = 1;
+          capsuleCollider.isTrigger = true;
+          triggerGameObject.transform.localPosition = source.position;
+          triggerGameObject.transform.localRotation = source.rotation;
+          break;
+
+        default:
+          AddUnknownShapeWarning(result, source.shapeType.ToString());
+          break;
+      }
+    }
+
+    private static void AddUnknownShapeWarning(VRCContactConversionResult result, string shapeType)
+    {
+      var message = "Unknown shape type " + shapeType + ". The converted object was created without a mapped collider.";
+      Debug.LogError(message);
+      result.Messages.Add(new ConversionMessage(ConversionMessageSeverity.Warning, "unknown_shape", message));
+    }
+
+    private static void ConfigureTriggerProperties(
+      VRCContactReceiver source,
+      object cvrTrigger,
+      Type cvrTriggerType
+    )
+    {
+      var areaSizeValue = new Vector3(source.radius / 100, source.radius / 100, source.radius / 100);
+      SetFieldOrProperty(cvrTriggerType, cvrTrigger, "areaSize", areaSizeValue);
+
+      SetFieldOrProperty(cvrTriggerType, cvrTrigger, "useAdvancedTrigger", true);
+      SetFieldOrProperty(cvrTriggerType, cvrTrigger, "isLocalInteractable", source.allowSelf);
+      SetFieldOrProperty(cvrTriggerType, cvrTrigger, "isNetworkInteractable", source.allowOthers);
+      SetFieldOrProperty(cvrTriggerType, cvrTrigger, "allowParticleInteraction", false);
+      SetFieldOrProperty(cvrTriggerType, cvrTrigger, "allowedTypes", source.collisionTags.ToArray());
+    }
+
+    private static void ConfigureTriggerTasks(
+      VRCContactReceiver source,
+      object cvrTrigger,
+      Type cvrTriggerType,
+      Type cvrTriggerTaskType,
+      Type cvrTriggerTaskStayType
+    )
+    {
+      switch (source.receiverType)
+      {
+        case VRC.Dynamics.ContactReceiver.ReceiverType.Constant:
+          ConfigureConstantTasks(source, cvrTrigger, cvrTriggerType, cvrTriggerTaskType);
+          break;
+
+        case VRC.Dynamics.ContactReceiver.ReceiverType.OnEnter:
+          ConfigureOnEnterTasks(source, cvrTrigger, cvrTriggerType, cvrTriggerTaskType);
+          break;
+
+        case VRC.Dynamics.ContactReceiver.ReceiverType.Proximity:
+          ConfigureProximityTasks(source, cvrTrigger, cvrTriggerType, cvrTriggerTaskStayType);
+          break;
+
+        default:
+          Debug.LogError("Unknown receiver type " + source.receiverType);
+          break;
+      }
+    }
+
+    private static void ConfigureConstantTasks(
+      VRCContactReceiver source,
+      object cvrTrigger,
+      Type cvrTriggerType,
+      Type cvrTriggerTaskType
+    )
+    {
+      var onEnterTask = Activator.CreateInstance(cvrTriggerTaskType);
+      ConfigureTriggerTask(onEnterTask, cvrTriggerTaskType, source.parameter, 1f, 0f, 0f, UPDATE_METHOD_OVERRIDE);
+
+      var onExitTask = Activator.CreateInstance(cvrTriggerTaskType);
+      ConfigureTriggerTask(onExitTask, cvrTriggerTaskType, source.parameter, 0f, 0f, 0f, UPDATE_METHOD_OVERRIDE);
+
+      AddTaskToList(cvrTrigger, cvrTriggerType, "enterTasks", onEnterTask);
+      AddTaskToList(cvrTrigger, cvrTriggerType, "exitTasks", onExitTask);
+    }
+
+    private static void ConfigureOnEnterTasks(
+      VRCContactReceiver source,
+      object cvrTrigger,
+      Type cvrTriggerType,
+      Type cvrTriggerTaskType
+    )
+    {
+      var onEnterTask = Activator.CreateInstance(cvrTriggerTaskType);
+      ConfigureTriggerTask(onEnterTask, cvrTriggerTaskType, source.parameter, 1f, 0f, 0f, UPDATE_METHOD_OVERRIDE);
+
+      var onEnterDelayed = Activator.CreateInstance(cvrTriggerTaskType);
+      ConfigureTriggerTask(onEnterDelayed, cvrTriggerTaskType, source.parameter, 0f, 0.5f, 0f, UPDATE_METHOD_OVERRIDE);
+
+      AddTaskToList(cvrTrigger, cvrTriggerType, "enterTasks", onEnterTask);
+      AddTaskToList(cvrTrigger, cvrTriggerType, "enterTasks", onEnterDelayed);
+    }
+
+    private static void ConfigureProximityTasks(
+      VRCContactReceiver source,
+      object cvrTrigger,
+      Type cvrTriggerType,
+      Type cvrTriggerTaskStayType
+    )
+    {
+      var onStayTask = Activator.CreateInstance(cvrTriggerTaskStayType);
+
+      SetFieldOrProperty(cvrTriggerTaskStayType, onStayTask, "settingName", source.parameter);
+      SetFieldOrProperty(cvrTriggerTaskStayType, onStayTask, "minValue", 1f);
+      SetFieldOrProperty(cvrTriggerTaskStayType, onStayTask, "maxValue", 0f);
+
+      var updateMethodType = cvrTriggerTaskStayType.GetNestedType("UpdateMethod");
+      if (updateMethodType != null && updateMethodType.IsEnum)
+      {
+        var setFromDistanceValue = Enum.Parse(updateMethodType, "SetFromDistance");
+        SetFieldOrProperty(cvrTriggerTaskStayType, onStayTask, "updateMethod", setFromDistanceValue);
+      }
+
+      AddTaskToList(cvrTrigger, cvrTriggerType, "stayTasks", onStayTask);
+    }
+
+    private static void ConfigureTriggerTask(
+      object task,
+      Type taskType,
+      string parameterName,
+      float value,
+      float delay,
+      float holdTime,
+      string updateMethod
+    )
+    {
+      SetFieldOrProperty(taskType, task, "settingName", parameterName);
+      SetFieldOrProperty(taskType, task, "settingValue", value);
+      SetFieldOrProperty(taskType, task, "delay", delay);
+      SetFieldOrProperty(taskType, task, "holdTime", holdTime);
+
+      var updateMethodType = taskType.GetNestedType("UpdateMethod");
+      if (updateMethodType != null && updateMethodType.IsEnum)
+      {
+        var updateMethodValue = Enum.Parse(updateMethodType, updateMethod);
+        SetFieldOrProperty(taskType, task, "updateMethod", updateMethodValue);
+      }
+    }
+
+    private static void AddTaskToList(object cvrTrigger, Type cvrTriggerType, string listPropertyName, object task)
+    {
+      var listProperty = cvrTriggerType.GetField(listPropertyName);
+      if (listProperty == null)
+        return;
+
+      var list = listProperty.GetValue(cvrTrigger) as IList;
+      if (list != null)
+        list.Add(task);
+    }
+
+    private static void SetFieldOrProperty(Type type, object instance, string memberName, object value)
+    {
+      var field = type.GetField(memberName);
+      if (field != null)
+      {
+        field.SetValue(instance, value);
+        return;
+      }
+
+      var property = type.GetProperty(memberName);
+      if (property != null)
+        property.SetValue(instance, value, null);
+    }
+
+    private struct ReceiverCVRTypes
+    {
+      public readonly Type triggerType;
+      public readonly Type taskType;
+      public readonly Type taskStayType;
+
+      public ReceiverCVRTypes(Type triggerType, Type taskType, Type taskStayType)
+      {
+        this.triggerType = triggerType;
+        this.taskType = taskType;
+        this.taskStayType = taskStayType;
+      }
+    }
+  }
+}

--- a/VRCStubConvertAndUI/VRCPCUIAndConverter/Conversion/VRCContactConversionTypes.cs
+++ b/VRCStubConvertAndUI/VRCPCUIAndConverter/Conversion/VRCContactConversionTypes.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace uk.novavoidhowl.dev.cvrfury.compiled.vrccontacts
+{
+  public enum ConversionMessageSeverity
+  {
+    Info,
+    Warning,
+    Error
+  }
+
+  public sealed class ConversionMessage
+  {
+    public ConversionMessageSeverity Severity;
+    public string Code;
+    public string Text;
+
+    public ConversionMessage(ConversionMessageSeverity severity, string code, string text)
+    {
+      Severity = severity;
+      Code = code;
+      Text = text;
+    }
+  }
+
+  public sealed class VRCContactConversionOptions
+  {
+    public bool RemoveSourceComponent = true;
+    public bool RegisterUndo;
+
+    public static VRCContactConversionOptions ForInspector()
+    {
+      return new VRCContactConversionOptions();
+    }
+
+    public static VRCContactConversionOptions ForBatch()
+    {
+      return new VRCContactConversionOptions { RegisterUndo = true };
+    }
+  }
+
+  public sealed class VRCContactConversionAvailability
+  {
+    public bool IsAvailable;
+    public readonly List<ConversionMessage> Messages = new List<ConversionMessage>();
+  }
+
+  public sealed class VRCContactConversionGuidance
+  {
+    public readonly List<ConversionMessage> Messages = new List<ConversionMessage>();
+  }
+
+  public sealed class VRCContactConversionResult
+  {
+    public bool Success;
+    public bool SourceRemoved;
+    public string SummaryTitle;
+    public string SummaryMessage;
+    public readonly List<GameObject> CreatedObjects = new List<GameObject>();
+    public readonly List<ConversionMessage> Messages = new List<ConversionMessage>();
+
+    public static VRCContactConversionResult Failed(string title, string message, string code)
+    {
+      var result = new VRCContactConversionResult
+      {
+        Success = false,
+        SummaryTitle = title,
+        SummaryMessage = message
+      };
+      result.Messages.Add(new ConversionMessage(ConversionMessageSeverity.Error, code, message));
+      return result;
+    }
+  }
+}

--- a/VRCStubConvertAndUI/VRCPCUIAndConverter/Editors/VRCContactReceiverEditor.cs
+++ b/VRCStubConvertAndUI/VRCPCUIAndConverter/Editors/VRCContactReceiverEditor.cs
@@ -7,6 +7,7 @@ using UnityEditor;
 using UnityEditor.UIElements;
 using VRC.SDK3.Dynamics.Contact.Components;
 using VRC.SDK3.Dynamics.Contact.Editors.Common;
+using uk.novavoidhowl.dev.cvrfury.compiled.vrccontacts;
 using uk.novavoidhowl.dev.cvrfury.VRCstub.Common; // Shared UI styles
 
 namespace VRC.SDK3.Dynamics.Contact.Editors
@@ -25,8 +26,6 @@ namespace VRC.SDK3.Dynamics.Contact.Editors
     private const string CSS_SPACER = "spacer";
     private const string STUB_VERSION = "stub-version";
     private const string UI_VERSION = "ui-version";
-    private const string UPDATE_METHOD_OVERRIDE = "Override";
-
     private static void ApplyCVRFuryStyles(VisualElement root)
     {
       SharedUIStyles.ApplySharedStyles(root);
@@ -41,319 +40,26 @@ namespace VRC.SDK3.Dynamics.Contact.Editors
     /// </summary>
     private void ConvertVRCContactReceiverToCVR()
     {
-      var vrcReceiver = (VRCContactReceiver)target;
-      var receiverGameObject = vrcReceiver.gameObject;
-
-      // Find required CVR component types using reflection
-      var (cvrTriggerType, cvrTriggerTaskType, cvrTriggerTaskStayType) = FindRequiredCVRTypes();
-
-      if (cvrTriggerType == null || cvrTriggerTaskType == null || cvrTriggerTaskStayType == null)
-      {
-        Debug.LogError("Could not find required CVR component types. Make sure CVR CCK is imported.");
-        return;
-      }
-
-      // Determine the parent transform for converted trigger
-      // If rootTransform is set, use that; otherwise use the receiver's transform
-      var parentTransform =
-        vrcReceiver.rootTransform != null ? vrcReceiver.rootTransform : receiverGameObject.transform;
-
-      // Create a new child GameObject for the trigger
-      var triggerGameObject = new GameObject($"CVR_Trigger_From_{receiverGameObject.name}");
-      triggerGameObject.transform.SetParent(parentTransform, false);
-
-      // Add appropriate collider based on shape type
-      AddColliderBasedOnShape(vrcReceiver, triggerGameObject);
-
-      // Add CVR trigger component
-      var cvrTrigger = triggerGameObject.AddComponent(cvrTriggerType);
-
-      // Configure trigger properties
-      ConfigureTriggerProperties(vrcReceiver, cvrTrigger, cvrTriggerType);
-
-      // Configure trigger tasks based on receiver type
-      ConfigureTriggerTasks(vrcReceiver, cvrTrigger, cvrTriggerType, cvrTriggerTaskType, cvrTriggerTaskStayType);
-
-      ShowConversionCompleteDialog();
-
-      // Mark objects as dirty for saving
-      EditorUtility.SetDirty(triggerGameObject);
-      EditorUtility.SetDirty(receiverGameObject);
-      if (vrcReceiver.rootTransform != null)
-      {
-        EditorUtility.SetDirty(vrcReceiver.rootTransform.gameObject);
-      }
-
-      // Remove the original VRC component
-      DestroyImmediate(vrcReceiver);
-    }
-
-    /// <summary>
-    /// Finds the required CVR component types using reflection.
-    /// </summary>
-    private static (Type triggerType, Type taskType, Type taskStayType) FindRequiredCVRTypes()
-    {
-      var triggerType = AppDomain.CurrentDomain
-        .GetAssemblies()
-        .SelectMany(a => a.GetTypes())
-        .FirstOrDefault(t => t.Name == "CVRAdvancedAvatarSettingsTrigger");
-
-      var taskType = AppDomain.CurrentDomain
-        .GetAssemblies()
-        .SelectMany(a => a.GetTypes())
-        .FirstOrDefault(t => t.Name == "CVRAdvancedAvatarSettingsTriggerTask");
-
-      var taskStayType = AppDomain.CurrentDomain
-        .GetAssemblies()
-        .SelectMany(a => a.GetTypes())
-        .FirstOrDefault(t => t.Name == "CVRAdvancedAvatarSettingsTriggerTaskStay");
-
-      return (triggerType, taskType, taskStayType);
-    }
-
-    /// <summary>
-    /// Adds the appropriate collider component based on the VRC receiver's shape type.
-    /// </summary>
-    private static void AddColliderBasedOnShape(VRCContactReceiver vrcReceiver, GameObject triggerGameObject)
-    {
-      switch (vrcReceiver.shapeType)
-      {
-        case VRC.Dynamics.ContactBase.ShapeType.Sphere:
-          var sphereCollider = triggerGameObject.AddComponent<SphereCollider>();
-          sphereCollider.radius = vrcReceiver.radius;
-          sphereCollider.isTrigger = true;
-          triggerGameObject.transform.localPosition = vrcReceiver.position;
-          break;
-
-        case VRC.Dynamics.ContactBase.ShapeType.Capsule:
-          var capsuleCollider = triggerGameObject.AddComponent<CapsuleCollider>();
-          capsuleCollider.radius = vrcReceiver.radius;
-          capsuleCollider.height = vrcReceiver.height;
-          capsuleCollider.direction = 1;
-          capsuleCollider.isTrigger = true;
-          triggerGameObject.transform.localPosition = vrcReceiver.position;
-          triggerGameObject.transform.localRotation = vrcReceiver.rotation;
-          break;
-
-        default:
-          Debug.LogError($"Unknown shape type {vrcReceiver.shapeType}");
-          break;
-      }
-    }
-
-    /// <summary>
-    /// Configures the basic properties of the CVR trigger component.
-    /// </summary>
-    private static void ConfigureTriggerProperties(
-      VRCContactReceiver vrcReceiver,
-      object cvrTrigger,
-      Type cvrTriggerType
-    )
-    {
-      // Set area size to a small fraction of the collider radius for distance-based triggers
-      var areaSizeValue = new Vector3(vrcReceiver.radius / 100, vrcReceiver.radius / 100, vrcReceiver.radius / 100);
-      SetFieldOrProperty(cvrTriggerType, cvrTrigger, "areaSize", areaSizeValue);
-
-      // Configure advanced trigger settings
-      SetFieldOrProperty(cvrTriggerType, cvrTrigger, "useAdvancedTrigger", true);
-      SetFieldOrProperty(cvrTriggerType, cvrTrigger, "isLocalInteractable", vrcReceiver.allowSelf);
-      SetFieldOrProperty(cvrTriggerType, cvrTrigger, "isNetworkInteractable", vrcReceiver.allowOthers);
-      SetFieldOrProperty(cvrTriggerType, cvrTrigger, "allowParticleInteraction", false);
-
-      // Set allowed types from collision tags
-      var allowedTypes = vrcReceiver.collisionTags.ToArray();
-      SetFieldOrProperty(cvrTriggerType, cvrTrigger, "allowedTypes", allowedTypes);
-    }
-
-    /// <summary>
-    /// Configures trigger tasks based on the VRC receiver type.
-    /// </summary>
-    private static void ConfigureTriggerTasks(
-      VRCContactReceiver vrcReceiver,
-      object cvrTrigger,
-      Type cvrTriggerType,
-      Type cvrTriggerTaskType,
-      Type cvrTriggerTaskStayType
-    )
-    {
-      switch (vrcReceiver.receiverType)
-      {
-        case VRC.Dynamics.ContactReceiver.ReceiverType.Constant:
-          ConfigureConstantTasks(vrcReceiver, cvrTrigger, cvrTriggerType, cvrTriggerTaskType);
-          break;
-
-        case VRC.Dynamics.ContactReceiver.ReceiverType.OnEnter:
-          ConfigureOnEnterTasks(vrcReceiver, cvrTrigger, cvrTriggerType, cvrTriggerTaskType);
-          break;
-
-        case VRC.Dynamics.ContactReceiver.ReceiverType.Proximity:
-          ConfigureProximityTasks(vrcReceiver, cvrTrigger, cvrTriggerType, cvrTriggerTaskStayType);
-          break;
-
-        default:
-          Debug.LogError($"Unknown receiver type {vrcReceiver.receiverType}");
-          break;
-      }
-    }
-
-    /// <summary>
-    /// Configures tasks for Constant receiver type.
-    /// </summary>
-    private static void ConfigureConstantTasks(
-      VRCContactReceiver vrcReceiver,
-      object cvrTrigger,
-      Type cvrTriggerType,
-      Type cvrTriggerTaskType
-    )
-    {
-      // Create enter task (set to 1)
-      var onEnterTask = Activator.CreateInstance(cvrTriggerTaskType);
-      ConfigureTriggerTask(onEnterTask, cvrTriggerTaskType, vrcReceiver.parameter, 1f, 0f, 0f, UPDATE_METHOD_OVERRIDE);
-
-      // Create exit task (set to 0)
-      var onExitTask = Activator.CreateInstance(cvrTriggerTaskType);
-      ConfigureTriggerTask(onExitTask, cvrTriggerTaskType, vrcReceiver.parameter, 0f, 0f, 0f, UPDATE_METHOD_OVERRIDE);
-
-      // Add tasks to trigger
-      AddTaskToList(cvrTrigger, cvrTriggerType, "enterTasks", onEnterTask);
-      AddTaskToList(cvrTrigger, cvrTriggerType, "exitTasks", onExitTask);
-    }
-
-    /// <summary>
-    /// Configures tasks for OnEnter receiver type.
-    /// </summary>
-    private static void ConfigureOnEnterTasks(
-      VRCContactReceiver vrcReceiver,
-      object cvrTrigger,
-      Type cvrTriggerType,
-      Type cvrTriggerTaskType
-    )
-    {
-      // Create immediate enter task (set to 1)
-      var onEnterTask = Activator.CreateInstance(cvrTriggerTaskType);
-      ConfigureTriggerTask(onEnterTask, cvrTriggerTaskType, vrcReceiver.parameter, 1f, 0f, 0f, UPDATE_METHOD_OVERRIDE);
-
-      // Create delayed enter task (set to 0 after delay to create pulse effect)
-      var onEnterDelayed = Activator.CreateInstance(cvrTriggerTaskType);
-      ConfigureTriggerTask(
-        onEnterDelayed,
-        cvrTriggerTaskType,
-        vrcReceiver.parameter,
-        0f,
-        0.5f,
-        0f,
-        UPDATE_METHOD_OVERRIDE
+      var result = VRCContactConversionActions.ConvertReceiver(
+        (VRCContactReceiver)target,
+        VRCContactConversionOptions.ForInspector()
       );
-
-      // Add tasks to trigger
-      AddTaskToList(cvrTrigger, cvrTriggerType, "enterTasks", onEnterTask);
-      AddTaskToList(cvrTrigger, cvrTriggerType, "enterTasks", onEnterDelayed);
+      ShowConversionResultDialog(result);
     }
 
-    /// <summary>
-    /// Configures tasks for Proximity receiver type.
-    /// </summary>
-    private static void ConfigureProximityTasks(
-      VRCContactReceiver vrcReceiver,
-      object cvrTrigger,
-      Type cvrTriggerType,
-      Type cvrTriggerTaskStayType
-    )
+    private static void ShowConversionResultDialog(VRCContactConversionResult result)
     {
-      // Create proximity stay task
-      var onStayTask = Activator.CreateInstance(cvrTriggerTaskStayType);
-
-      // Configure the stay task for distance-based updates
-      SetFieldOrProperty(cvrTriggerTaskStayType, onStayTask, "settingName", vrcReceiver.parameter);
-      SetFieldOrProperty(cvrTriggerTaskStayType, onStayTask, "minValue", 1f);
-      SetFieldOrProperty(cvrTriggerTaskStayType, onStayTask, "maxValue", 0f);
-
-      // Set update method to SetFromDistance using enum conversion
-      var updateMethodType = cvrTriggerTaskStayType.GetNestedType("UpdateMethod");
-      if (updateMethodType != null && updateMethodType.IsEnum)
+      var message = result.SummaryMessage;
+      if (result.Messages.Count > 0)
       {
-        var setFromDistanceValue = Enum.Parse(updateMethodType, "SetFromDistance");
-        SetFieldOrProperty(cvrTriggerTaskStayType, onStayTask, "updateMethod", setFromDistanceValue);
-      }
-
-      // Add task to trigger
-      AddTaskToList(cvrTrigger, cvrTriggerType, "stayTasks", onStayTask);
-    }
-
-    /// <summary>
-    /// Configures a basic trigger task with common properties.
-    /// </summary>
-    private static void ConfigureTriggerTask(
-      object task,
-      Type taskType,
-      string parameterName,
-      float value,
-      float delay,
-      float holdTime,
-      string updateMethod
-    )
-    {
-      SetFieldOrProperty(taskType, task, "settingName", parameterName);
-      SetFieldOrProperty(taskType, task, "settingValue", value);
-      SetFieldOrProperty(taskType, task, "delay", delay);
-      SetFieldOrProperty(taskType, task, "holdTime", holdTime);
-
-      // Set update method using enum conversion
-      var updateMethodType = taskType.GetNestedType("UpdateMethod");
-      if (updateMethodType != null && updateMethodType.IsEnum)
-      {
-        var updateMethodValue = Enum.Parse(updateMethodType, updateMethod);
-        SetFieldOrProperty(taskType, task, "updateMethod", updateMethodValue);
-      }
-    }
-
-    /// <summary>
-    /// Adds a task to a list property on the trigger component.
-    /// </summary>
-    private static void AddTaskToList(object cvrTrigger, Type cvrTriggerType, string listPropertyName, object task)
-    {
-      var listProperty = cvrTriggerType.GetField(listPropertyName);
-      if (listProperty != null)
-      {
-        var list = listProperty.GetValue(cvrTrigger) as System.Collections.IList;
-        if (list != null)
+        message += "\n\nMessages:";
+        foreach (var conversionMessage in result.Messages)
         {
-          list.Add(task);
+          message += "\n- " + conversionMessage.Text;
         }
       }
-    }
 
-    /// <summary>
-    /// Sets a field or property value on an object using reflection.
-    /// </summary>
-    private static void SetFieldOrProperty(Type type, object instance, string memberName, object value)
-    {
-      var field = type.GetField(memberName);
-      if (field != null)
-      {
-        field.SetValue(instance, value);
-        return;
-      }
-
-      var property = type.GetProperty(memberName);
-      if (property != null)
-      {
-        property.SetValue(instance, value, null);
-      }
-    }
-
-    /// <summary>
-    /// Shows the conversion complete dialog to the user.
-    /// </summary>
-    private static void ShowConversionCompleteDialog()
-    {
-      EditorUtility.DisplayDialog(
-        "Contact Receiver Conversion Complete",
-        "The VRC Contact Receiver has been successfully converted to a CVR Advanced Avatar Settings Trigger. "
-          + "The original component has been removed and a new child GameObject with the CVR trigger has been created. "
-          + "The trigger is placed under the rootTransform if set, otherwise under the original component's GameObject.",
-        "OK"
-      );
+      EditorUtility.DisplayDialog(result.SummaryTitle, message, "OK");
     }
 
     public override VisualElement CreateInspectorGUI()
@@ -365,7 +71,9 @@ namespace VRC.SDK3.Dynamics.Contact.Editors
       stubVersionLabel.AddToClassList(STUB_VERSION);
       root.Add(stubVersionLabel);
 
-      var uiVersionLabel = new Label($"UI Version: {UIVersion.CurrentVersion}");
+      var uiVersionLabel = new Label(
+        $"UI Version: {UIVersion.CurrentVersion} | API Version: {VRCContactConversionActions.ApiVersion}"
+      );
       uiVersionLabel.AddToClassList(UI_VERSION);
       root.Add(uiVersionLabel);
 

--- a/VRCStubConvertAndUI/VRCPCUIAndConverter/Editors/VRCContactReceiverEditor.cs
+++ b/VRCStubConvertAndUI/VRCPCUIAndConverter/Editors/VRCContactReceiverEditor.cs
@@ -53,9 +53,13 @@ namespace VRC.SDK3.Dynamics.Contact.Editors
         return;
       }
 
+      // Determine the parent transform for converted trigger
+      // If rootTransform is set, use that; otherwise use the receiver's transform
+      var parentTransform = vrcReceiver.rootTransform != null ? vrcReceiver.rootTransform : receiverGameObject.transform;
+
       // Create a new child GameObject for the trigger
       var triggerGameObject = new GameObject($"CVR_Trigger_From_{receiverGameObject.name}");
-      triggerGameObject.transform.SetParent(receiverGameObject.transform, false);
+      triggerGameObject.transform.SetParent(parentTransform, false);
 
       // Add appropriate collider based on shape type
       AddColliderBasedOnShape(vrcReceiver, triggerGameObject);
@@ -74,6 +78,10 @@ namespace VRC.SDK3.Dynamics.Contact.Editors
       // Mark objects as dirty for saving
       EditorUtility.SetDirty(triggerGameObject);
       EditorUtility.SetDirty(receiverGameObject);
+      if (vrcReceiver.rootTransform != null)
+      {
+        EditorUtility.SetDirty(vrcReceiver.rootTransform.gameObject);
+      }
 
       // Remove the original VRC component
       DestroyImmediate(vrcReceiver);
@@ -341,7 +349,8 @@ namespace VRC.SDK3.Dynamics.Contact.Editors
       EditorUtility.DisplayDialog(
         "Contact Receiver Conversion Complete",
         "The VRC Contact Receiver has been successfully converted to a CVR Advanced Avatar Settings Trigger. "
-          + "The original component has been removed and a new child GameObject with the CVR trigger has been created.",
+          + "The original component has been removed and a new child GameObject with the CVR trigger has been created. "
+          + "The trigger is placed under the rootTransform if set, otherwise under the original component's GameObject.",
         "OK"
       );
     }

--- a/VRCStubConvertAndUI/VRCPCUIAndConverter/Editors/VRCContactReceiverEditor.cs
+++ b/VRCStubConvertAndUI/VRCPCUIAndConverter/Editors/VRCContactReceiverEditor.cs
@@ -55,7 +55,8 @@ namespace VRC.SDK3.Dynamics.Contact.Editors
 
       // Determine the parent transform for converted trigger
       // If rootTransform is set, use that; otherwise use the receiver's transform
-      var parentTransform = vrcReceiver.rootTransform != null ? vrcReceiver.rootTransform : receiverGameObject.transform;
+      var parentTransform =
+        vrcReceiver.rootTransform != null ? vrcReceiver.rootTransform : receiverGameObject.transform;
 
       // Create a new child GameObject for the trigger
       var triggerGameObject = new GameObject($"CVR_Trigger_From_{receiverGameObject.name}");

--- a/VRCStubConvertAndUI/VRCPCUIAndConverter/Editors/VRCContactSenderEditor.cs
+++ b/VRCStubConvertAndUI/VRCPCUIAndConverter/Editors/VRCContactSenderEditor.cs
@@ -52,12 +52,16 @@ namespace VRC.SDK3.Dynamics.Contact.Editors
         return;
       }
 
+      // Determine the parent transform for converted pointers
+      // If rootTransform is set, use that; otherwise use the sender's transform
+      var parentTransform = vrcSender.rootTransform != null ? vrcSender.rootTransform : senderGameObject.transform;
+
       // Create a child GameObject for each collision tag
       for (int i = 0; i < vrcSender.collisionTags.Count; i++)
       {
         var collisionTag = vrcSender.collisionTags[i];
         var pointerGameObject = new GameObject($"CVR_Pointer{i + 1}_From_{senderGameObject.name}");
-        pointerGameObject.transform.SetParent(senderGameObject.transform, false);
+        pointerGameObject.transform.SetParent(parentTransform, false);
 
         // Add appropriate collider based on shape type
         AddColliderBasedOnShape(vrcSender, pointerGameObject);
@@ -71,6 +75,10 @@ namespace VRC.SDK3.Dynamics.Contact.Editors
 
       // Mark objects as dirty for saving
       EditorUtility.SetDirty(senderGameObject);
+      if (vrcSender.rootTransform != null)
+      {
+        EditorUtility.SetDirty(vrcSender.rootTransform.gameObject);
+      }
 
       // Remove the original VRC component
       DestroyImmediate(vrcSender);
@@ -145,7 +153,8 @@ namespace VRC.SDK3.Dynamics.Contact.Editors
         "Contact Sender Conversion Complete",
         "The VRC Contact Sender has been successfully converted to CVR Pointer(s). "
           + "The original component has been removed and new child GameObject(s) with CVR pointers have been created "
-          + "(one for each collision tag).",
+          + "(one for each collision tag). "
+          + "The pointers are placed under the rootTransform if set, otherwise under the original component's GameObject.",
         "OK"
       );
     }

--- a/VRCStubConvertAndUI/VRCPCUIAndConverter/Editors/VRCContactSenderEditor.cs
+++ b/VRCStubConvertAndUI/VRCPCUIAndConverter/Editors/VRCContactSenderEditor.cs
@@ -7,6 +7,7 @@ using UnityEditor;
 using UnityEditor.UIElements;
 using VRC.SDK3.Dynamics.Contact.Components;
 using VRC.SDK3.Dynamics.Contact.Editors.Common;
+using uk.novavoidhowl.dev.cvrfury.compiled.vrccontacts;
 using uk.novavoidhowl.dev.cvrfury.VRCstub.Common; // Shared UI styles
 
 namespace VRC.SDK3.Dynamics.Contact.Editors
@@ -40,123 +41,26 @@ namespace VRC.SDK3.Dynamics.Contact.Editors
     /// </summary>
     private void ConvertVRCContactSenderToCVR()
     {
-      var vrcSender = (VRCContactSender)target;
-      var senderGameObject = vrcSender.gameObject;
-
-      // Find required CVR component type using reflection
-      var cvrPointerType = FindRequiredCVRPointerType();
-
-      if (cvrPointerType == null)
-      {
-        Debug.LogError("Could not find CVRPointer component type. Make sure CVR CCK is imported.");
-        return;
-      }
-
-      // Determine the parent transform for converted pointers
-      // If rootTransform is set, use that; otherwise use the sender's transform
-      var parentTransform = vrcSender.rootTransform != null ? vrcSender.rootTransform : senderGameObject.transform;
-
-      // Create a child GameObject for each collision tag
-      for (int i = 0; i < vrcSender.collisionTags.Count; i++)
-      {
-        var collisionTag = vrcSender.collisionTags[i];
-        var pointerGameObject = new GameObject($"CVR_Pointer{i + 1}_From_{senderGameObject.name}");
-        pointerGameObject.transform.SetParent(parentTransform, false);
-
-        // Add appropriate collider based on shape type
-        AddColliderBasedOnShape(vrcSender, pointerGameObject);
-
-        // Add CVR pointer component for this collision tag
-        var cvrPointer = pointerGameObject.AddComponent(cvrPointerType);
-        SetFieldOrProperty(cvrPointerType, cvrPointer, "type", collisionTag);
-      }
-
-      ShowConversionCompleteDialog();
-
-      // Mark objects as dirty for saving
-      EditorUtility.SetDirty(senderGameObject);
-      if (vrcSender.rootTransform != null)
-      {
-        EditorUtility.SetDirty(vrcSender.rootTransform.gameObject);
-      }
-
-      // Remove the original VRC component
-      DestroyImmediate(vrcSender);
-    }
-
-    /// <summary>
-    /// Finds the CVR Pointer component type using reflection.
-    /// </summary>
-    private static Type FindRequiredCVRPointerType()
-    {
-      return AppDomain.CurrentDomain
-        .GetAssemblies()
-        .SelectMany(a => a.GetTypes())
-        .FirstOrDefault(t => t.Name == "CVRPointer");
-    }
-
-    /// <summary>
-    /// Adds the appropriate collider component based on the VRC sender's shape type.
-    /// </summary>
-    private static void AddColliderBasedOnShape(VRCContactSender vrcSender, GameObject pointerGameObject)
-    {
-      switch (vrcSender.shapeType)
-      {
-        case VRC.Dynamics.ContactBase.ShapeType.Sphere:
-          var sphereCollider = pointerGameObject.AddComponent<SphereCollider>();
-          sphereCollider.radius = vrcSender.radius;
-          sphereCollider.isTrigger = true;
-          pointerGameObject.transform.localPosition = vrcSender.position;
-          break;
-
-        case VRC.Dynamics.ContactBase.ShapeType.Capsule:
-          var capsuleCollider = pointerGameObject.AddComponent<CapsuleCollider>();
-          capsuleCollider.radius = vrcSender.radius;
-          capsuleCollider.height = vrcSender.height;
-          capsuleCollider.direction = 1;
-          capsuleCollider.isTrigger = true;
-          pointerGameObject.transform.localPosition = vrcSender.position;
-          pointerGameObject.transform.localRotation = vrcSender.rotation;
-          break;
-
-        default:
-          Debug.LogError($"Unknown shape type {vrcSender.shapeType}");
-          break;
-      }
-    }
-
-    /// <summary>
-    /// Sets a field or property value on an object using reflection.
-    /// </summary>
-    private static void SetFieldOrProperty(Type type, object instance, string memberName, object value)
-    {
-      var field = type.GetField(memberName);
-      if (field != null)
-      {
-        field.SetValue(instance, value);
-        return;
-      }
-
-      var property = type.GetProperty(memberName);
-      if (property != null)
-      {
-        property.SetValue(instance, value, null);
-      }
-    }
-
-    /// <summary>
-    /// Shows the conversion complete dialog to the user.
-    /// </summary>
-    private static void ShowConversionCompleteDialog()
-    {
-      EditorUtility.DisplayDialog(
-        "Contact Sender Conversion Complete",
-        "The VRC Contact Sender has been successfully converted to CVR Pointer(s). "
-          + "The original component has been removed and new child GameObject(s) with CVR pointers have been created "
-          + "(one for each collision tag). "
-          + "The pointers are placed under the rootTransform if set, otherwise under the original component's GameObject.",
-        "OK"
+      var result = VRCContactConversionActions.ConvertSender(
+        (VRCContactSender)target,
+        VRCContactConversionOptions.ForInspector()
       );
+      ShowConversionResultDialog(result);
+    }
+
+    private static void ShowConversionResultDialog(VRCContactConversionResult result)
+    {
+      var message = result.SummaryMessage;
+      if (result.Messages.Count > 0)
+      {
+        message += "\n\nMessages:";
+        foreach (var conversionMessage in result.Messages)
+        {
+          message += "\n- " + conversionMessage.Text;
+        }
+      }
+
+      EditorUtility.DisplayDialog(result.SummaryTitle, message, "OK");
     }
 
     public override VisualElement CreateInspectorGUI()
@@ -168,7 +72,9 @@ namespace VRC.SDK3.Dynamics.Contact.Editors
       stubVersionLabel.AddToClassList(STUB_VERSION);
       root.Add(stubVersionLabel);
 
-      var uiVersionLabel = new Label($"UI Version: {UIVersion.CurrentVersion}");
+      var uiVersionLabel = new Label(
+        $"UI Version: {UIVersion.CurrentVersion} | API Version: {VRCContactConversionActions.ApiVersion}"
+      );
       uiVersionLabel.AddToClassList(UI_VERSION);
       root.Add(uiVersionLabel);
 

--- a/VRCStubConvertAndUI/VRCPCUIAndConverter/VRCPCUIAndConverter.csproj
+++ b/VRCStubConvertAndUI/VRCPCUIAndConverter/VRCPCUIAndConverter.csproj
@@ -57,12 +57,16 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Common\APIVersion.cs" />
     <Compile Include="Common\UIVersion.cs" />
+    <Compile Include="Conversion\VRCContactConversionActions.cs" />
+    <Compile Include="Conversion\VRCContactConversionTypes.cs" />
     <Compile Include="Editors\VRCContactSenderEditor.cs" />
     <Compile Include="Editors\VRCContactReceiverEditor.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Common\" />
+    <Folder Include="Conversion\" />
     <Folder Include="Editors\" />
     <Folder Include="Resources\" />
   </ItemGroup>

--- a/VRCStubConvertAndUI/VRCPConUIAndConverter/Common/APIVersion.cs
+++ b/VRCStubConvertAndUI/VRCPConUIAndConverter/Common/APIVersion.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace uk.novavoidhowl.dev.cvrfury.compiled.vrcconstraints
+{
+  public static class APIVersion
+  {
+    private static readonly Version _version = new Version(1, 0, 0);
+
+    public static string CurrentVersion
+    {
+      get { return _version.ToString(); }
+    }
+
+    public static Version AsVersion
+    {
+      get { return _version; }
+    }
+
+    public static bool IsVersionAtLeast(Version otherVersion)
+    {
+      return _version >= otherVersion;
+    }
+
+    public static bool IsVersionAtLeast(string versionString)
+    {
+      Version otherVersion;
+      if (Version.TryParse(versionString, out otherVersion))
+      {
+        return IsVersionAtLeast(otherVersion);
+      }
+      return false;
+    }
+  }
+}

--- a/VRCStubConvertAndUI/VRCPConUIAndConverter/Common/UIVersion.cs
+++ b/VRCStubConvertAndUI/VRCPConUIAndConverter/Common/UIVersion.cs
@@ -4,7 +4,7 @@ namespace VRC.SDK3.Dynamics.Constraint.Editors.Common
 {
   public static class UIVersion
   {
-    private static readonly Version _version = new Version(2, 0, 0);
+    private static readonly Version _version = new Version(2, 1, 0);
 
     // For serialization and display
     public static string CurrentVersion => _version.ToString();

--- a/VRCStubConvertAndUI/VRCPConUIAndConverter/Conversion/VRCConstraintConversionActions.cs
+++ b/VRCStubConvertAndUI/VRCPConUIAndConverter/Conversion/VRCConstraintConversionActions.cs
@@ -1,0 +1,403 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Animations;
+using VRC.Dynamics.ManagedTypes;
+using VRC.SDK3.Dynamics.Constraint.Components;
+
+namespace uk.novavoidhowl.dev.cvrfury.compiled.vrcconstraints
+{
+  public static class VRCConstraintConversionActions
+  {
+    public static string ApiVersion
+    {
+      get { return APIVersion.CurrentVersion; }
+    }
+
+    public static Version ApiVersionAsVersion
+    {
+      get { return APIVersion.AsVersion; }
+    }
+
+    public static bool IsApiVersionAtLeast(Version otherVersion)
+    {
+      return APIVersion.IsVersionAtLeast(otherVersion);
+    }
+
+    public static bool IsApiVersionAtLeast(string otherVersion)
+    {
+      return APIVersion.IsVersionAtLeast(otherVersion);
+    }
+
+    public static VRCConstraintConversionAvailability GetAvailability(Component source)
+    {
+      VRCConstraintKind kind;
+      var availability = new VRCConstraintConversionAvailability
+      {
+        IsAvailable = TryGetKind(source, out kind),
+        Kind = kind
+      };
+
+      if (!availability.IsAvailable)
+      {
+        availability.Messages.Add(
+          new ConversionMessage(
+            ConversionMessageSeverity.Error,
+            "unsupported_constraint",
+            "This component is not a supported VRC constraint conversion source."
+          )
+        );
+      }
+
+      return availability;
+    }
+
+    public static VRCConstraintConversionGuidance GetGuidance(Component source)
+    {
+      VRCConstraintKind kind;
+      TryGetKind(source, out kind);
+
+      var guidance = new VRCConstraintConversionGuidance { Kind = kind };
+      guidance.Messages.Add(
+        new ConversionMessage(
+          ConversionMessageSeverity.Info,
+          "constraint_destructive_conversion",
+          "VRC constraint conversion adds the matching Unity constraint component to the same GameObject and removes the source VRC constraint after success."
+        )
+      );
+      guidance.Messages.Add(
+        new ConversionMessage(
+          ConversionMessageSeverity.Info,
+          "constraint_one_to_one_mapping",
+          "Supported VRC constraints map one-to-one to Aim, LookAt, Parent, Position, Rotation, or Scale Unity constraints."
+        )
+      );
+      return guidance;
+    }
+
+    public static VRCConstraintConversionResult Convert(
+      Component source,
+      VRCConstraintConversionOptions options
+    )
+    {
+      if (source == null)
+        return VRCConstraintConversionResult.Failed("Constraint Conversion Failed", "Source constraint is missing.", "missing_source");
+
+      if (options == null)
+        options = VRCConstraintConversionOptions.ForInspector();
+
+      if (source is VRCAimConstraint)
+        return ConvertAim((VRCAimConstraint)source, options);
+      if (source is VRCLookAtConstraint)
+        return ConvertLookAt((VRCLookAtConstraint)source, options);
+      if (source is VRCParentConstraint)
+        return ConvertParent((VRCParentConstraint)source, options);
+      if (source is VRCPositionConstraint)
+        return ConvertPosition((VRCPositionConstraint)source, options);
+      if (source is VRCRotationConstraint)
+        return ConvertRotation((VRCRotationConstraint)source, options);
+      if (source is VRCScaleConstraint)
+        return ConvertScale((VRCScaleConstraint)source, options);
+
+      return VRCConstraintConversionResult.Failed(
+        "Constraint Conversion Failed",
+        "This component is not a supported VRC constraint conversion source.",
+        "unsupported_constraint"
+      );
+    }
+
+    private static VRCConstraintConversionResult ConvertAim(
+      VRCAimConstraint source,
+      VRCConstraintConversionOptions options
+    )
+    {
+      var unityConstraint = AddComponent<AimConstraint>(source.gameObject, options);
+
+      unityConstraint.weight = source.GlobalWeight;
+      unityConstraint.constraintActive = source.IsActive;
+      unityConstraint.aimVector = source.AimAxis;
+      unityConstraint.upVector = source.UpAxis;
+
+      switch (source.WorldUp)
+      {
+        case VRC.Dynamics.ManagedTypes.VRCConstraintBase.WorldUpType.SceneUp:
+          unityConstraint.worldUpType = AimConstraint.WorldUpType.SceneUp;
+          break;
+        case VRC.Dynamics.ManagedTypes.VRCConstraintBase.WorldUpType.ObjectUp:
+          unityConstraint.worldUpType = AimConstraint.WorldUpType.ObjectUp;
+          unityConstraint.worldUpObject = source.WorldUpTransform;
+          break;
+        case VRC.Dynamics.ManagedTypes.VRCConstraintBase.WorldUpType.ObjectRotationUp:
+          unityConstraint.worldUpType = AimConstraint.WorldUpType.ObjectRotationUp;
+          unityConstraint.worldUpObject = source.WorldUpTransform;
+          break;
+        case VRC.Dynamics.ManagedTypes.VRCConstraintBase.WorldUpType.Vector:
+          unityConstraint.worldUpType = AimConstraint.WorldUpType.Vector;
+          unityConstraint.worldUpVector = source.WorldUpVector;
+          break;
+        case VRC.Dynamics.ManagedTypes.VRCConstraintBase.WorldUpType.None:
+          unityConstraint.worldUpType = AimConstraint.WorldUpType.None;
+          break;
+      }
+
+      AddSources(source.Sources, unityConstraint);
+
+      unityConstraint.rotationAxis = 0;
+      if (source.AffectsRotationX)
+        unityConstraint.rotationAxis |= Axis.X;
+      if (source.AffectsRotationY)
+        unityConstraint.rotationAxis |= Axis.Y;
+      if (source.AffectsRotationZ)
+        unityConstraint.rotationAxis |= Axis.Z;
+
+      return BuildSuccess(source, unityConstraint, VRCConstraintKind.Aim, "Unity AimConstraint", options);
+    }
+
+    private static VRCConstraintConversionResult ConvertLookAt(
+      VRCLookAtConstraint source,
+      VRCConstraintConversionOptions options
+    )
+    {
+      var unityConstraint = AddComponent<LookAtConstraint>(source.gameObject, options);
+
+      unityConstraint.weight = source.GlobalWeight;
+      unityConstraint.constraintActive = source.IsActive;
+      unityConstraint.roll = source.Roll;
+      unityConstraint.useUpObject = source.UseUpTransform;
+      if (source.UseUpTransform && source.WorldUpTransform != null)
+        unityConstraint.worldUpObject = source.WorldUpTransform;
+
+      AddSources(source.Sources, unityConstraint);
+
+      return BuildSuccess(source, unityConstraint, VRCConstraintKind.LookAt, "Unity LookAtConstraint", options);
+    }
+
+    private static VRCConstraintConversionResult ConvertParent(
+      VRCParentConstraint source,
+      VRCConstraintConversionOptions options
+    )
+    {
+      var unityConstraint = AddComponent<ParentConstraint>(source.gameObject, options);
+
+      unityConstraint.weight = source.GlobalWeight;
+      unityConstraint.constraintActive = source.IsActive;
+      unityConstraint.translationAtRest = source.PositionAtRest;
+      unityConstraint.rotationAtRest = source.RotationAtRest;
+
+      for (int i = 0; i < source.Sources.Count; i++)
+      {
+        var vrcSource = source.Sources[i];
+        if (vrcSource.SourceTransform == null)
+          continue;
+
+        var unitySource = new ConstraintSource
+        {
+          sourceTransform = vrcSource.SourceTransform,
+          weight = vrcSource.Weight
+        };
+        int sourceIndex = unityConstraint.AddSource(unitySource);
+        unityConstraint.SetTranslationOffset(sourceIndex, vrcSource.ParentPositionOffset);
+        unityConstraint.SetRotationOffset(sourceIndex, vrcSource.ParentRotationOffset);
+      }
+
+      unityConstraint.translationAxis = 0;
+      if (source.AffectsPositionX)
+        unityConstraint.translationAxis |= Axis.X;
+      if (source.AffectsPositionY)
+        unityConstraint.translationAxis |= Axis.Y;
+      if (source.AffectsPositionZ)
+        unityConstraint.translationAxis |= Axis.Z;
+
+      unityConstraint.rotationAxis = 0;
+      if (source.AffectsRotationX)
+        unityConstraint.rotationAxis |= Axis.X;
+      if (source.AffectsRotationY)
+        unityConstraint.rotationAxis |= Axis.Y;
+      if (source.AffectsRotationZ)
+        unityConstraint.rotationAxis |= Axis.Z;
+
+      return BuildSuccess(source, unityConstraint, VRCConstraintKind.Parent, "Unity ParentConstraint", options);
+    }
+
+    private static VRCConstraintConversionResult ConvertPosition(
+      VRCPositionConstraint source,
+      VRCConstraintConversionOptions options
+    )
+    {
+      var unityConstraint = AddComponent<PositionConstraint>(source.gameObject, options);
+
+      unityConstraint.weight = source.GlobalWeight;
+      unityConstraint.constraintActive = source.IsActive;
+      unityConstraint.translationAtRest = source.PositionAtRest;
+      unityConstraint.translationOffset = source.PositionOffset;
+
+      AddSources(source.Sources, unityConstraint);
+
+      unityConstraint.translationAxis = 0;
+      if (source.AffectsPositionX)
+        unityConstraint.translationAxis |= Axis.X;
+      if (source.AffectsPositionY)
+        unityConstraint.translationAxis |= Axis.Y;
+      if (source.AffectsPositionZ)
+        unityConstraint.translationAxis |= Axis.Z;
+
+      return BuildSuccess(source, unityConstraint, VRCConstraintKind.Position, "Unity PositionConstraint", options);
+    }
+
+    private static VRCConstraintConversionResult ConvertRotation(
+      VRCRotationConstraint source,
+      VRCConstraintConversionOptions options
+    )
+    {
+      var unityConstraint = AddComponent<RotationConstraint>(source.gameObject, options);
+
+      unityConstraint.weight = source.GlobalWeight;
+      unityConstraint.constraintActive = source.IsActive;
+      unityConstraint.rotationAtRest = source.RotationAtRest;
+      unityConstraint.rotationOffset = source.RotationOffset;
+
+      AddSources(source.Sources, unityConstraint);
+
+      unityConstraint.rotationAxis = 0;
+      if (source.AffectsRotationX)
+        unityConstraint.rotationAxis |= Axis.X;
+      if (source.AffectsRotationY)
+        unityConstraint.rotationAxis |= Axis.Y;
+      if (source.AffectsRotationZ)
+        unityConstraint.rotationAxis |= Axis.Z;
+
+      return BuildSuccess(source, unityConstraint, VRCConstraintKind.Rotation, "Unity RotationConstraint", options);
+    }
+
+    private static VRCConstraintConversionResult ConvertScale(
+      VRCScaleConstraint source,
+      VRCConstraintConversionOptions options
+    )
+    {
+      var unityConstraint = AddComponent<ScaleConstraint>(source.gameObject, options);
+
+      unityConstraint.weight = source.GlobalWeight;
+      unityConstraint.constraintActive = source.IsActive;
+      unityConstraint.scaleAtRest = source.ScaleAtRest;
+      unityConstraint.scaleOffset = source.ScaleOffset;
+
+      AddSources(source.Sources, unityConstraint);
+
+      unityConstraint.scalingAxis = 0;
+      if (source.AffectsScaleX)
+        unityConstraint.scalingAxis |= Axis.X;
+      if (source.AffectsScaleY)
+        unityConstraint.scalingAxis |= Axis.Y;
+      if (source.AffectsScaleZ)
+        unityConstraint.scalingAxis |= Axis.Z;
+
+      return BuildSuccess(source, unityConstraint, VRCConstraintKind.Scale, "Unity ScaleConstraint", options);
+    }
+
+    private static T AddComponent<T>(GameObject gameObject, VRCConstraintConversionOptions options)
+      where T : Component
+    {
+      if (options.RegisterUndo)
+        return Undo.AddComponent<T>(gameObject);
+
+      return gameObject.AddComponent<T>();
+    }
+
+    private static void AddSources<T>(VRCConstraintSourceKeyableList sources, T unityConstraint)
+      where T : Behaviour, IConstraint
+    {
+      for (int i = 0; i < sources.Count; i++)
+      {
+        var vrcSource = sources[i];
+        if (vrcSource.SourceTransform == null)
+          continue;
+
+        var unitySource = new ConstraintSource
+        {
+          sourceTransform = vrcSource.SourceTransform,
+          weight = vrcSource.Weight
+        };
+        unityConstraint.AddSource(unitySource);
+      }
+    }
+
+    private static VRCConstraintConversionResult BuildSuccess(
+      Component source,
+      Component unityConstraint,
+      VRCConstraintKind kind,
+      string targetName,
+      VRCConstraintConversionOptions options
+    )
+    {
+      var gameObject = source.gameObject;
+      var result = new VRCConstraintConversionResult
+      {
+        Success = true,
+        Kind = kind,
+        SourceGameObject = gameObject,
+        CreatedConstraint = unityConstraint,
+        SummaryTitle = "Constraint Conversion Complete",
+        SummaryMessage = "Successfully converted to " + targetName + "."
+      };
+
+      foreach (var message in GetGuidance(source).Messages)
+        result.Messages.Add(message);
+
+      EditorUtility.SetDirty(gameObject);
+      EditorUtility.SetDirty(unityConstraint);
+
+      if (options.RemoveSourceComponent)
+      {
+        DestroyComponent(source, options);
+        result.SourceRemoved = true;
+      }
+
+      return result;
+    }
+
+    private static void DestroyComponent(Component component, VRCConstraintConversionOptions options)
+    {
+      if (options.RegisterUndo)
+        Undo.DestroyObjectImmediate(component);
+      else
+        UnityEngine.Object.DestroyImmediate(component);
+    }
+
+    private static bool TryGetKind(Component source, out VRCConstraintKind kind)
+    {
+      if (source is VRCAimConstraint)
+      {
+        kind = VRCConstraintKind.Aim;
+        return true;
+      }
+      if (source is VRCLookAtConstraint)
+      {
+        kind = VRCConstraintKind.LookAt;
+        return true;
+      }
+      if (source is VRCParentConstraint)
+      {
+        kind = VRCConstraintKind.Parent;
+        return true;
+      }
+      if (source is VRCPositionConstraint)
+      {
+        kind = VRCConstraintKind.Position;
+        return true;
+      }
+      if (source is VRCRotationConstraint)
+      {
+        kind = VRCConstraintKind.Rotation;
+        return true;
+      }
+      if (source is VRCScaleConstraint)
+      {
+        kind = VRCConstraintKind.Scale;
+        return true;
+      }
+
+      kind = default(VRCConstraintKind);
+      return false;
+    }
+  }
+}

--- a/VRCStubConvertAndUI/VRCPConUIAndConverter/Conversion/VRCConstraintConversionTypes.cs
+++ b/VRCStubConvertAndUI/VRCPConUIAndConverter/Conversion/VRCConstraintConversionTypes.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace uk.novavoidhowl.dev.cvrfury.compiled.vrcconstraints
+{
+  public enum ConversionMessageSeverity
+  {
+    Info,
+    Warning,
+    Error
+  }
+
+  public sealed class ConversionMessage
+  {
+    public ConversionMessageSeverity Severity;
+    public string Code;
+    public string Text;
+
+    public ConversionMessage(ConversionMessageSeverity severity, string code, string text)
+    {
+      Severity = severity;
+      Code = code;
+      Text = text;
+    }
+  }
+
+  public enum VRCConstraintKind
+  {
+    Aim,
+    LookAt,
+    Parent,
+    Position,
+    Rotation,
+    Scale
+  }
+
+  public sealed class VRCConstraintConversionOptions
+  {
+    public bool RemoveSourceComponent = true;
+    public bool RegisterUndo = true;
+
+    public static VRCConstraintConversionOptions ForInspector()
+    {
+      return new VRCConstraintConversionOptions();
+    }
+
+    public static VRCConstraintConversionOptions ForBatch()
+    {
+      return new VRCConstraintConversionOptions();
+    }
+  }
+
+  public sealed class VRCConstraintConversionAvailability
+  {
+    public bool IsAvailable;
+    public VRCConstraintKind Kind;
+    public readonly List<ConversionMessage> Messages = new List<ConversionMessage>();
+  }
+
+  public sealed class VRCConstraintConversionGuidance
+  {
+    public VRCConstraintKind Kind;
+    public readonly List<ConversionMessage> Messages = new List<ConversionMessage>();
+  }
+
+  public sealed class VRCConstraintConversionResult
+  {
+    public bool Success;
+    public bool SourceRemoved;
+    public VRCConstraintKind Kind;
+    public GameObject SourceGameObject;
+    public Component CreatedConstraint;
+    public string SummaryTitle;
+    public string SummaryMessage;
+    public readonly List<ConversionMessage> Messages = new List<ConversionMessage>();
+
+    public static VRCConstraintConversionResult Failed(string title, string message, string code)
+    {
+      var result = new VRCConstraintConversionResult
+      {
+        Success = false,
+        SummaryTitle = title,
+        SummaryMessage = message
+      };
+      result.Messages.Add(new ConversionMessage(ConversionMessageSeverity.Error, code, message));
+      return result;
+    }
+  }
+}

--- a/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCAimConstraintEditor.cs
+++ b/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCAimConstraintEditor.cs
@@ -6,6 +6,7 @@ using UnityEngine.Animations;
 using VRC.Dynamics.ManagedTypes;
 using VRC.SDK3.Dynamics.Constraint.Components;
 using VRC.SDK3.Dynamics.Constraint.Editors.Common;
+using uk.novavoidhowl.dev.cvrfury.compiled.vrcconstraints;
 using uk.novavoidhowl.dev.cvrfury.VRCstub.Common; // Shared UI styles
 using System;
 
@@ -68,7 +69,7 @@ namespace VRC.SDK3.Dynamics.Constraint.Editors
       stubVersionLabel.style.fontSize = new StyleLength(10);
       stubVersionLabel.style.color = new StyleColor(Color.gray);
 
-      var uiVersionLabel = new Label($"UI: {UIVersion.CurrentVersion}");
+      var uiVersionLabel = new Label($"UI: {UIVersion.CurrentVersion} | API: {VRCConstraintConversionActions.ApiVersion}");
       uiVersionLabel.AddToClassList(UI_VERSION);
       uiVersionLabel.style.fontSize = new StyleLength(10);
       uiVersionLabel.style.color = new StyleColor(Color.gray);
@@ -85,71 +86,8 @@ namespace VRC.SDK3.Dynamics.Constraint.Editors
 
     private void ConvertToUnityConstraint()
     {
-      VRCAimConstraint vrcConstraint = (VRCAimConstraint)target;
-      GameObject gameObject = vrcConstraint.gameObject;
-
-      // Add Unity AimConstraint component
-      AimConstraint unityConstraint = Undo.AddComponent<AimConstraint>(gameObject);
-
-      // Transfer basic properties
-      unityConstraint.weight = vrcConstraint.GlobalWeight;
-      unityConstraint.constraintActive = vrcConstraint.IsActive;
-
-      // Set aim vector
-      unityConstraint.aimVector = vrcConstraint.AimAxis;
-      unityConstraint.upVector = vrcConstraint.UpAxis;
-
-      // Set world up type
-      switch (vrcConstraint.WorldUp)
-      {
-        case VRC.Dynamics.ManagedTypes.VRCConstraintBase.WorldUpType.SceneUp:
-          unityConstraint.worldUpType = AimConstraint.WorldUpType.SceneUp;
-          break;
-        case VRC.Dynamics.ManagedTypes.VRCConstraintBase.WorldUpType.ObjectUp:
-          unityConstraint.worldUpType = AimConstraint.WorldUpType.ObjectUp;
-          unityConstraint.worldUpObject = vrcConstraint.WorldUpTransform;
-          break;
-        case VRC.Dynamics.ManagedTypes.VRCConstraintBase.WorldUpType.ObjectRotationUp:
-          unityConstraint.worldUpType = AimConstraint.WorldUpType.ObjectRotationUp;
-          unityConstraint.worldUpObject = vrcConstraint.WorldUpTransform;
-          break;
-        case VRC.Dynamics.ManagedTypes.VRCConstraintBase.WorldUpType.Vector:
-          unityConstraint.worldUpType = AimConstraint.WorldUpType.Vector;
-          unityConstraint.worldUpVector = vrcConstraint.WorldUpVector;
-          break;
-        case VRC.Dynamics.ManagedTypes.VRCConstraintBase.WorldUpType.None:
-          unityConstraint.worldUpType = AimConstraint.WorldUpType.None;
-          break;
-      }
-
-      // Add sources
-      for (int i = 0; i < vrcConstraint.Sources.Count; i++)
-      {
-        var vrcSource = vrcConstraint.Sources[i];
-        if (vrcSource.SourceTransform != null)
-        {
-          ConstraintSource unitySource = new ConstraintSource
-          {
-            sourceTransform = vrcSource.SourceTransform,
-            weight = vrcSource.Weight
-          };
-          unityConstraint.AddSource(unitySource);
-        }
-      }
-
-      // Set axes
-      unityConstraint.rotationAxis = 0;
-      if (vrcConstraint.AffectsRotationX)
-        unityConstraint.rotationAxis |= Axis.X;
-      if (vrcConstraint.AffectsRotationY)
-        unityConstraint.rotationAxis |= Axis.Y;
-      if (vrcConstraint.AffectsRotationZ)
-        unityConstraint.rotationAxis |= Axis.Z;
-
-      // Remove VRC component after conversion
-      Undo.DestroyObjectImmediate(vrcConstraint);
-
-      EditorUtility.DisplayDialog("Conversion Complete", "Successfully converted to Unity AimConstraint", "OK");
+      var result = VRCConstraintConversionActions.Convert((Component)target, VRCConstraintConversionOptions.ForInspector());
+      VRCConstraintConversionEditorDialog.Show(result);
     }
   }
 }

--- a/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCConstraintConversionEditorDialog.cs
+++ b/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCConstraintConversionEditorDialog.cs
@@ -1,0 +1,25 @@
+using System.Text;
+using UnityEditor;
+using uk.novavoidhowl.dev.cvrfury.compiled.vrcconstraints;
+
+namespace VRC.SDK3.Dynamics.Constraint.Editors
+{
+  internal static class VRCConstraintConversionEditorDialog
+  {
+    public static void Show(VRCConstraintConversionResult result)
+    {
+      var message = new StringBuilder(result.SummaryMessage);
+
+      foreach (var conversionMessage in result.Messages)
+      {
+        if (conversionMessage.Severity == ConversionMessageSeverity.Info)
+          continue;
+
+        message.AppendLine();
+        message.AppendLine(conversionMessage.Severity + ": " + conversionMessage.Text);
+      }
+
+      EditorUtility.DisplayDialog(result.SummaryTitle, message.ToString(), "OK");
+    }
+  }
+}

--- a/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCLookAtConstraintEditor.cs
+++ b/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCLookAtConstraintEditor.cs
@@ -6,6 +6,7 @@ using UnityEngine.Animations;
 using VRC.Dynamics.ManagedTypes;
 using VRC.SDK3.Dynamics.Constraint.Components;
 using VRC.SDK3.Dynamics.Constraint.Editors.Common;
+using uk.novavoidhowl.dev.cvrfury.compiled.vrcconstraints;
 using uk.novavoidhowl.dev.cvrfury.VRCstub.Common; // Shared UI styles
 using System;
 
@@ -68,7 +69,7 @@ namespace VRC.SDK3.Dynamics.Constraint.Editors
       stubVersionLabel.style.fontSize = new StyleLength(10);
       stubVersionLabel.style.color = new StyleColor(Color.gray);
 
-      var uiVersionLabel = new Label($"UI: {UIVersion.CurrentVersion}");
+      var uiVersionLabel = new Label($"UI: {UIVersion.CurrentVersion} | API: {VRCConstraintConversionActions.ApiVersion}");
       uiVersionLabel.AddToClassList(UI_VERSION);
       uiVersionLabel.style.fontSize = new StyleLength(10);
       uiVersionLabel.style.color = new StyleColor(Color.gray);
@@ -85,45 +86,8 @@ namespace VRC.SDK3.Dynamics.Constraint.Editors
 
     private void ConvertToUnityConstraint()
     {
-      VRCLookAtConstraint vrcConstraint = (VRCLookAtConstraint)target;
-      GameObject gameObject = vrcConstraint.gameObject;
-
-      // Add Unity LookAtConstraint component
-      LookAtConstraint unityConstraint = Undo.AddComponent<LookAtConstraint>(gameObject);
-
-      // Transfer basic properties
-      unityConstraint.weight = vrcConstraint.GlobalWeight;
-      unityConstraint.constraintActive = vrcConstraint.IsActive;
-
-      // Set rotation offset
-      unityConstraint.roll = vrcConstraint.Roll;
-
-      // Set world up settings
-      unityConstraint.useUpObject = vrcConstraint.UseUpTransform;
-      if (vrcConstraint.UseUpTransform && vrcConstraint.WorldUpTransform != null)
-      {
-        unityConstraint.worldUpObject = vrcConstraint.WorldUpTransform;
-      }
-
-      // Add sources
-      for (int i = 0; i < vrcConstraint.Sources.Count; i++)
-      {
-        var vrcSource = vrcConstraint.Sources[i];
-        if (vrcSource.SourceTransform != null)
-        {
-          ConstraintSource unitySource = new ConstraintSource
-          {
-            sourceTransform = vrcSource.SourceTransform,
-            weight = vrcSource.Weight
-          };
-          unityConstraint.AddSource(unitySource);
-        }
-      }
-
-      // Remove VRC component after conversion
-      Undo.DestroyObjectImmediate(vrcConstraint);
-
-      EditorUtility.DisplayDialog("Conversion Complete", "Successfully converted to Unity LookAtConstraint", "OK");
+      var result = VRCConstraintConversionActions.Convert((Component)target, VRCConstraintConversionOptions.ForInspector());
+      VRCConstraintConversionEditorDialog.Show(result);
     }
   }
 }

--- a/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCParentConstraintEditor.cs
+++ b/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCParentConstraintEditor.cs
@@ -6,6 +6,7 @@ using UnityEngine.Animations;
 using VRC.Dynamics.ManagedTypes;
 using VRC.SDK3.Dynamics.Constraint.Components;
 using VRC.SDK3.Dynamics.Constraint.Editors.Common;
+using uk.novavoidhowl.dev.cvrfury.compiled.vrcconstraints;
 using uk.novavoidhowl.dev.cvrfury.VRCstub.Common; // Shared UI styles
 using System;
 
@@ -68,7 +69,7 @@ namespace VRC.SDK3.Dynamics.Constraint.Editors
       stubVersionLabel.style.fontSize = new StyleLength(10);
       stubVersionLabel.style.color = new StyleColor(Color.gray);
 
-      var uiVersionLabel = new Label($"UI: {UIVersion.CurrentVersion}");
+      var uiVersionLabel = new Label($"UI: {UIVersion.CurrentVersion} | API: {VRCConstraintConversionActions.ApiVersion}");
       uiVersionLabel.AddToClassList(UI_VERSION);
       uiVersionLabel.style.fontSize = new StyleLength(10);
       uiVersionLabel.style.color = new StyleColor(Color.gray);
@@ -85,62 +86,8 @@ namespace VRC.SDK3.Dynamics.Constraint.Editors
 
     private void ConvertToUnityConstraint()
     {
-      VRCParentConstraint vrcConstraint = (VRCParentConstraint)target;
-      GameObject gameObject = vrcConstraint.gameObject;
-
-      // Add Unity ParentConstraint component
-      ParentConstraint unityConstraint = Undo.AddComponent<ParentConstraint>(gameObject);
-
-      // Transfer basic properties
-      unityConstraint.weight = vrcConstraint.GlobalWeight;
-      unityConstraint.constraintActive = vrcConstraint.IsActive;
-
-      // Set translation offset
-      unityConstraint.translationAtRest = vrcConstraint.PositionAtRest;
-
-      // Set rotation offset
-      unityConstraint.rotationAtRest = vrcConstraint.RotationAtRest;
-
-      // Add sources
-      for (int i = 0; i < vrcConstraint.Sources.Count; i++)
-      {
-        var vrcSource = vrcConstraint.Sources[i];
-        if (vrcSource.SourceTransform != null)
-        {
-          ConstraintSource unitySource = new ConstraintSource
-          {
-            sourceTransform = vrcSource.SourceTransform,
-            weight = vrcSource.Weight
-          };
-          int sourceIndex = unityConstraint.AddSource(unitySource);
-
-          // Set position and rotation offsets for this source
-          unityConstraint.SetTranslationOffset(sourceIndex, vrcSource.ParentPositionOffset);
-          unityConstraint.SetRotationOffset(sourceIndex, vrcSource.ParentRotationOffset);
-        }
-      }
-
-      // Set axes
-      unityConstraint.translationAxis = 0;
-      if (vrcConstraint.AffectsPositionX)
-        unityConstraint.translationAxis |= Axis.X;
-      if (vrcConstraint.AffectsPositionY)
-        unityConstraint.translationAxis |= Axis.Y;
-      if (vrcConstraint.AffectsPositionZ)
-        unityConstraint.translationAxis |= Axis.Z;
-
-      unityConstraint.rotationAxis = 0;
-      if (vrcConstraint.AffectsRotationX)
-        unityConstraint.rotationAxis |= Axis.X;
-      if (vrcConstraint.AffectsRotationY)
-        unityConstraint.rotationAxis |= Axis.Y;
-      if (vrcConstraint.AffectsRotationZ)
-        unityConstraint.rotationAxis |= Axis.Z;
-
-      // Remove VRC component after conversion
-      Undo.DestroyObjectImmediate(vrcConstraint);
-
-      EditorUtility.DisplayDialog("Conversion Complete", "Successfully converted to Unity ParentConstraint", "OK");
+      var result = VRCConstraintConversionActions.Convert((Component)target, VRCConstraintConversionOptions.ForInspector());
+      VRCConstraintConversionEditorDialog.Show(result);
     }
   }
 }

--- a/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCPositionConstraintEditor.cs
+++ b/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCPositionConstraintEditor.cs
@@ -6,6 +6,7 @@ using UnityEngine.Animations;
 using VRC.Dynamics.ManagedTypes;
 using VRC.SDK3.Dynamics.Constraint.Components;
 using VRC.SDK3.Dynamics.Constraint.Editors.Common;
+using uk.novavoidhowl.dev.cvrfury.compiled.vrcconstraints;
 using uk.novavoidhowl.dev.cvrfury.VRCstub.Common; // Shared UI styles
 using System;
 
@@ -68,7 +69,7 @@ namespace VRC.SDK3.Dynamics.Constraint.Editors
       stubVersionLabel.style.fontSize = new StyleLength(10);
       stubVersionLabel.style.color = new StyleColor(Color.gray);
 
-      var uiVersionLabel = new Label($"UI: {UIVersion.CurrentVersion}");
+      var uiVersionLabel = new Label($"UI: {UIVersion.CurrentVersion} | API: {VRCConstraintConversionActions.ApiVersion}");
       uiVersionLabel.AddToClassList(UI_VERSION);
       uiVersionLabel.style.fontSize = new StyleLength(10);
       uiVersionLabel.style.color = new StyleColor(Color.gray);
@@ -85,50 +86,8 @@ namespace VRC.SDK3.Dynamics.Constraint.Editors
 
     private void ConvertToUnityConstraint()
     {
-      VRCPositionConstraint vrcConstraint = (VRCPositionConstraint)target;
-      GameObject gameObject = vrcConstraint.gameObject;
-
-      // Add Unity PositionConstraint component
-      PositionConstraint unityConstraint = Undo.AddComponent<PositionConstraint>(gameObject);
-
-      // Transfer basic properties
-      unityConstraint.weight = vrcConstraint.GlobalWeight;
-      unityConstraint.constraintActive = vrcConstraint.IsActive;
-
-      // Set at rest position
-      unityConstraint.translationAtRest = vrcConstraint.PositionAtRest;
-
-      // Set offset
-      unityConstraint.translationOffset = vrcConstraint.PositionOffset;
-
-      // Add sources
-      for (int i = 0; i < vrcConstraint.Sources.Count; i++)
-      {
-        var vrcSource = vrcConstraint.Sources[i];
-        if (vrcSource.SourceTransform != null)
-        {
-          ConstraintSource unitySource = new ConstraintSource
-          {
-            sourceTransform = vrcSource.SourceTransform,
-            weight = vrcSource.Weight
-          };
-          unityConstraint.AddSource(unitySource);
-        }
-      }
-
-      // Set axes
-      unityConstraint.translationAxis = 0;
-      if (vrcConstraint.AffectsPositionX)
-        unityConstraint.translationAxis |= Axis.X;
-      if (vrcConstraint.AffectsPositionY)
-        unityConstraint.translationAxis |= Axis.Y;
-      if (vrcConstraint.AffectsPositionZ)
-        unityConstraint.translationAxis |= Axis.Z;
-
-      // Remove VRC component after conversion
-      Undo.DestroyObjectImmediate(vrcConstraint);
-
-      EditorUtility.DisplayDialog("Conversion Complete", "Successfully converted to Unity PositionConstraint", "OK");
+      var result = VRCConstraintConversionActions.Convert((Component)target, VRCConstraintConversionOptions.ForInspector());
+      VRCConstraintConversionEditorDialog.Show(result);
     }
   }
 }

--- a/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCRotationConstraintEditor.cs
+++ b/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCRotationConstraintEditor.cs
@@ -6,6 +6,7 @@ using UnityEngine.Animations;
 using VRC.Dynamics.ManagedTypes;
 using VRC.SDK3.Dynamics.Constraint.Components;
 using VRC.SDK3.Dynamics.Constraint.Editors.Common;
+using uk.novavoidhowl.dev.cvrfury.compiled.vrcconstraints;
 using uk.novavoidhowl.dev.cvrfury.VRCstub.Common; // Shared UI styles
 using System;
 
@@ -68,7 +69,7 @@ namespace VRC.SDK3.Dynamics.Constraint.Editors
       stubVersionLabel.style.fontSize = new StyleLength(10);
       stubVersionLabel.style.color = new StyleColor(Color.gray);
 
-      var uiVersionLabel = new Label($"UI: {UIVersion.CurrentVersion}");
+      var uiVersionLabel = new Label($"UI: {UIVersion.CurrentVersion} | API: {VRCConstraintConversionActions.ApiVersion}");
       uiVersionLabel.AddToClassList(UI_VERSION);
       uiVersionLabel.style.fontSize = new StyleLength(10);
       uiVersionLabel.style.color = new StyleColor(Color.gray);
@@ -85,50 +86,8 @@ namespace VRC.SDK3.Dynamics.Constraint.Editors
 
     private void ConvertToUnityConstraint()
     {
-      VRCRotationConstraint vrcConstraint = (VRCRotationConstraint)target;
-      GameObject gameObject = vrcConstraint.gameObject;
-
-      // Add Unity RotationConstraint component
-      RotationConstraint unityConstraint = Undo.AddComponent<RotationConstraint>(gameObject);
-
-      // Transfer basic properties
-      unityConstraint.weight = vrcConstraint.GlobalWeight;
-      unityConstraint.constraintActive = vrcConstraint.IsActive;
-
-      // Set at rest rotation
-      unityConstraint.rotationAtRest = vrcConstraint.RotationAtRest;
-
-      // Set offset
-      unityConstraint.rotationOffset = vrcConstraint.RotationOffset;
-
-      // Add sources
-      for (int i = 0; i < vrcConstraint.Sources.Count; i++)
-      {
-        var vrcSource = vrcConstraint.Sources[i];
-        if (vrcSource.SourceTransform != null)
-        {
-          ConstraintSource unitySource = new ConstraintSource
-          {
-            sourceTransform = vrcSource.SourceTransform,
-            weight = vrcSource.Weight
-          };
-          unityConstraint.AddSource(unitySource);
-        }
-      }
-
-      // Set axes
-      unityConstraint.rotationAxis = 0;
-      if (vrcConstraint.AffectsRotationX)
-        unityConstraint.rotationAxis |= Axis.X;
-      if (vrcConstraint.AffectsRotationY)
-        unityConstraint.rotationAxis |= Axis.Y;
-      if (vrcConstraint.AffectsRotationZ)
-        unityConstraint.rotationAxis |= Axis.Z;
-
-      // Remove VRC component after conversion
-      Undo.DestroyObjectImmediate(vrcConstraint);
-
-      EditorUtility.DisplayDialog("Conversion Complete", "Successfully converted to Unity RotationConstraint", "OK");
+      var result = VRCConstraintConversionActions.Convert((Component)target, VRCConstraintConversionOptions.ForInspector());
+      VRCConstraintConversionEditorDialog.Show(result);
     }
   }
 }

--- a/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCScaleConstraintEditor.cs
+++ b/VRCStubConvertAndUI/VRCPConUIAndConverter/Editors/VRCScaleConstraintEditor.cs
@@ -6,6 +6,7 @@ using UnityEngine.Animations;
 using VRC.Dynamics.ManagedTypes;
 using VRC.SDK3.Dynamics.Constraint.Components;
 using VRC.SDK3.Dynamics.Constraint.Editors.Common;
+using uk.novavoidhowl.dev.cvrfury.compiled.vrcconstraints;
 using uk.novavoidhowl.dev.cvrfury.VRCstub.Common; // Shared UI styles
 using System;
 
@@ -68,7 +69,7 @@ namespace VRC.SDK3.Dynamics.Constraint.Editors
       stubVersionLabel.style.fontSize = new StyleLength(10);
       stubVersionLabel.style.color = new StyleColor(Color.gray);
 
-      var uiVersionLabel = new Label($"UI: {UIVersion.CurrentVersion}");
+      var uiVersionLabel = new Label($"UI: {UIVersion.CurrentVersion} | API: {VRCConstraintConversionActions.ApiVersion}");
       uiVersionLabel.AddToClassList(UI_VERSION);
       uiVersionLabel.style.fontSize = new StyleLength(10);
       uiVersionLabel.style.color = new StyleColor(Color.gray);
@@ -85,50 +86,8 @@ namespace VRC.SDK3.Dynamics.Constraint.Editors
 
     private void ConvertToUnityConstraint()
     {
-      VRCScaleConstraint vrcConstraint = (VRCScaleConstraint)target;
-      GameObject gameObject = vrcConstraint.gameObject;
-
-      // Add Unity ScaleConstraint component
-      ScaleConstraint unityConstraint = Undo.AddComponent<ScaleConstraint>(gameObject);
-
-      // Transfer basic properties
-      unityConstraint.weight = vrcConstraint.GlobalWeight;
-      unityConstraint.constraintActive = vrcConstraint.IsActive;
-
-      // Set at rest scale
-      unityConstraint.scaleAtRest = vrcConstraint.ScaleAtRest;
-
-      // Set offset
-      unityConstraint.scaleOffset = vrcConstraint.ScaleOffset;
-
-      // Add sources
-      for (int i = 0; i < vrcConstraint.Sources.Count; i++)
-      {
-        var vrcSource = vrcConstraint.Sources[i];
-        if (vrcSource.SourceTransform != null)
-        {
-          ConstraintSource unitySource = new ConstraintSource
-          {
-            sourceTransform = vrcSource.SourceTransform,
-            weight = vrcSource.Weight
-          };
-          unityConstraint.AddSource(unitySource);
-        }
-      }
-
-      // Set axes
-      unityConstraint.scalingAxis = 0;
-      if (vrcConstraint.AffectsScaleX)
-        unityConstraint.scalingAxis |= Axis.X;
-      if (vrcConstraint.AffectsScaleY)
-        unityConstraint.scalingAxis |= Axis.Y;
-      if (vrcConstraint.AffectsScaleZ)
-        unityConstraint.scalingAxis |= Axis.Z;
-
-      // Remove VRC component after conversion
-      Undo.DestroyObjectImmediate(vrcConstraint);
-
-      EditorUtility.DisplayDialog("Conversion Complete", "Successfully converted to Unity ScaleConstraint", "OK");
+      var result = VRCConstraintConversionActions.Convert((Component)target, VRCConstraintConversionOptions.ForInspector());
+      VRCConstraintConversionEditorDialog.Show(result);
     }
   }
 }

--- a/VRCStubConvertAndUI/VRCPConUIAndConverter/VRCPConUIAndConverter.csproj
+++ b/VRCStubConvertAndUI/VRCPConUIAndConverter/VRCPConUIAndConverter.csproj
@@ -57,7 +57,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Common\APIVersion.cs" />
     <Compile Include="Common\UIVersion.cs" />
+    <Compile Include="Conversion\VRCConstraintConversionActions.cs" />
+    <Compile Include="Conversion\VRCConstraintConversionTypes.cs" />
+    <Compile Include="Editors\VRCConstraintConversionEditorDialog.cs" />
     <Compile Include="Editors\VRCAimConstraintEditor.cs" />
     <Compile Include="Editors\VRCLookAtConstraintEditor.cs" />
     <Compile Include="Editors\VRCParentConstraintEditor.cs" />
@@ -67,6 +71,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Common\" />
+    <Folder Include="Conversion\" />
     <Folder Include="Editors\" />
     <Folder Include="Resources\" />
   </ItemGroup>

--- a/docs/contact-converter.md
+++ b/docs/contact-converter.md
@@ -1,0 +1,218 @@
+# Contact Converter
+
+Convert VRC Contact Sender and VRC Contact Receiver components to CVR-compatible
+components directly from the Unity Inspector.
+
+---
+
+## Status
+
+Implemented and live in the custom inspectors.
+
+This document reflects current behavior:
+
+- Sender conversion creates one CVRPointer per collision tag.
+- Receiver conversion creates one CVRAdvancedAvatarSettingsTrigger.
+- Converted objects are parented under rootTransform when set.
+- If rootTransform is not set, converted objects are parented under the source component GameObject.
+- Source VRC contact component is removed after successful conversion.
+
+---
+
+## File Location
+
+Primary implementation files:
+
+- CVRFury-Compiled-Components/VRCStubConvertAndUI/VRCPCUIAndConverter/Editors/VRCContactSenderEditor.cs
+- CVRFury-Compiled-Components/VRCStubConvertAndUI/VRCPCUIAndConverter/Editors/VRCContactReceiverEditor.cs
+
+---
+
+## Runtime Package Detection
+
+Because these editors are compiled into precompiled DLLs, CVR support is detected at runtime via reflection type lookup.
+
+Sender converter requires:
+
+- CVRPointer
+
+Receiver converter requires:
+
+- CVRAdvancedAvatarSettingsTrigger
+- CVRAdvancedAvatarSettingsTriggerTask
+- CVRAdvancedAvatarSettingsTriggerTaskStay
+
+If required types are missing, conversion logs an error and does not modify the source component.
+
+---
+
+## Inspector UI Behavior
+
+Both inspectors show:
+
+1. Stub version label.
+2. UI version label.
+3. Warning/info box explaining conversion requirement.
+4. Single Convert button.
+
+Sender button:
+
+- Convert to Chillout VR Pointer
+
+Receiver button:
+
+- Convert to Chillout VR Advanced Avatar Settings Trigger
+
+Current behavior is one-way conversion. There is no Re-Convert button because the
+source component is removed once conversion succeeds. This is due to the fact that there
+is only one possible item to convert to, rather than multiple options like colliders have.
+
+---
+
+## Effective Root and Placement
+
+Effective parent transform is:
+
+- src.rootTransform when set, otherwise
+- src.transform
+
+Converted child GameObjects are created under that effective parent.
+
+This means:
+
+- If rootTransform is assigned, source position is applied relative to a zeroed local transform under rootTransform.
+- If rootTransform is not assigned, behavior matches legacy placement under the original component GameObject.
+
+---
+
+## Contact Sender Conversion
+
+### Output
+
+For each collision tag in sender.collisionTags:
+
+- Create child GameObject named CVR_Pointer{index}_From_{sourceName}.
+- Add trigger collider mapped from source shape.
+- Add CVRPointer component.
+- Set pointer type from that collision tag.
+
+### Shape mapping
+
+Sphere:
+
+- Add SphereCollider.
+- radius = sender.radius
+- isTrigger = true
+- localPosition = sender.position
+
+Capsule:
+
+- Add CapsuleCollider.
+- radius = sender.radius
+- height = sender.height
+- direction = 1 (Y axis)
+- isTrigger = true
+- localPosition = sender.position
+- localRotation = sender.rotation
+
+Unknown shape types log an error.
+
+---
+
+## Contact Receiver Conversion
+
+### Output
+
+- Create one child GameObject named CVR_Trigger_From_{sourceName}.
+- Add trigger collider mapped from source shape.
+- Add CVRAdvancedAvatarSettingsTrigger component.
+- Configure trigger settings and tasks based on receiver type.
+
+### Base trigger property mapping
+
+- areaSize = new Vector3(radius / 100, radius / 100, radius / 100)
+- useAdvancedTrigger = true
+- isLocalInteractable = allowSelf
+- isNetworkInteractable = allowOthers
+- allowParticleInteraction = false
+- allowedTypes = collisionTags array
+
+### Shape mapping
+
+Sphere:
+
+- Add SphereCollider.
+- radius = receiver.radius
+- isTrigger = true
+- localPosition = receiver.position
+
+Capsule:
+
+- Add CapsuleCollider.
+- radius = receiver.radius
+- height = receiver.height
+- direction = 1 (Y axis)
+- isTrigger = true
+- localPosition = receiver.position
+- localRotation = receiver.rotation
+
+Unknown shape types log an error.
+
+### Receiver type task mapping
+
+Constant:
+
+- enterTasks: settingValue 1.0, delay 0, holdTime 0, updateMethod Override
+- exitTasks: settingValue 0.0, delay 0, holdTime 0, updateMethod Override
+
+OnEnter:
+
+- enterTasks task 1: settingValue 1.0, delay 0, holdTime 0, updateMethod Override
+- enterTasks task 2: settingValue 0.0, delay 0.5, holdTime 0, updateMethod Override
+
+Proximity:
+
+- stayTasks: minValue 1.0, maxValue 0.0, updateMethod SetFromDistance
+
+All task entries use settingName = receiver.parameter.
+
+---
+
+## Reflection and Field/Property Assignment
+
+Converters use helper logic that attempts field assignment first, then property assignment.
+
+This supports minor API differences between CCK versions where members may be fields or properties.
+
+---
+
+## Dirty Marking and Source Removal
+
+After successful conversion:
+
+- Sender: marks source GameObject dirty, and rootTransform GameObject dirty when present.
+- Receiver: marks new trigger GameObject dirty, source GameObject dirty, and rootTransform GameObject dirty when present.
+- Original VRC contact component is removed with DestroyImmediate.
+
+---
+
+## Current Limitations
+
+- No marker ownership system is used for contacts.
+- No update-in-place reconversion path exists.
+- Conversion is destructive to the source component (component removal).
+- Converted naming may create duplicates if users manually recreate VRC components and convert repeatedly.
+
+---
+
+## Functional Summary
+
+Current contact converter behavior is:
+
+- Runtime type detection for CVR target types
+- Sender to CVRPointer conversion per collision tag
+- Receiver to CVRAdvancedAvatarSettingsTrigger conversion with receiver-type task mapping
+- rootTransform-aware placement for both sender and receiver conversions
+- Automatic source component removal after conversion
+
+This is the current baseline for future contact-converter enhancements.


### PR DESCRIPTION
## In this merge:
- Added shared conversion action APIs for VRC Contact Sender/Receiver, VRC PhysBone Collider, and all supported VRC Constraints
- Added strongly typed conversion models per domain so conversion can be triggered programmatically by external tooling
- Updated existing inspector editors to call the new shared APIs, keeping inspector and batch workflows on one conversion path
- Added shared constraint conversion editor dialog support aligned with the new API entry points
- Added per-module API version metadata and updated UI versions to reflect the new public conversion surface
- Updated project files to include and compile the new shared conversion API/type sources
- Added contact converter documentation and kept rootTransform-aware sender/receiver behavior intact

## Notes
This is the compiled-components foundation for the completed mass conversion tooling work.

The key architecture improvement is that single-item inspector conversion and bulk conversion now execute the same conversion logic:

- Reduced duplication by moving converter behavior into shared action classes
- Lower risk of behavior drift between inspector and mass-action workflows
- Cleaner editor code with a clearer API boundary for downstream tooling
- Versioned API surface to support safer future evolution

Net result: a more maintainable conversion stack, more predictable conversion behavior across UI paths, and a stable API layer for mass conversion features.